### PR TITLE
Fix Mac dev install instructions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,5 +28,5 @@ jobs:
         sudo apt-get update
         python -m pip install --upgrade pip
         pip install .
-        pip install .[test]
+        pip install .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/README.md
+++ b/README.md
@@ -34,3 +34,10 @@ $ git clone https://github.com/astronomy-commons/hipscat
 $ cd hipscat
 $ pip install -e .
 ```
+
+### Installing dev dependencies on Mac
+
+```bash
+$ pip install '.[dev]'
+```
+(Make sure to include the single quotes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)
 [project.optional-dependencies]
-test = [
+dev = [
     "pytest", 
     "pytest-cov",
 ]


### PR DESCRIPTION
This changes the name of the dev dependencies in the pyproject.toml file to match the project template, and the instructions commented in the file.

The CI has been updated to match this, and the README has been updated to include the instructions.