### PR TITLE
Add Pixel Node class for representing hipscat trees

### DIFF
--- a/src/hipscat/catalog/pixel_node.py
+++ b/src/hipscat/catalog/pixel_node.py
@@ -77,7 +77,7 @@ class PixelNode:
     def _add_all_leaf_descendants_rec(self, leaf_descendants: List[PixelNode]):
         """Recursively add all leaf descendants to list
 
-        list must be created outside function, done for efficiency vs adding lists
+        list must be created outside function, done for efficiency vs list concat
         """
         if self.node_type == PixelNodeType.LEAF:
             leaf_descendants.append(self)

--- a/src/hipscat/catalog/pixel_node.py
+++ b/src/hipscat/catalog/pixel_node.py
@@ -54,7 +54,7 @@ class PixelNode:
         """Adds a child node to the node
 
         Args:
-            child: child to add
+            child: child node to add
         """
         self.children.append(child)
 
@@ -64,16 +64,23 @@ class PixelNode:
         Leafs nodes correspond to pixels that have data files containing astronomical objects, so this method is used
         to get the files containing all astronomical objects within the pixel
 
-        This function called on a leaf node returns a list including the node itself
+        This function called on a leaf node returns a list including the node itself and only itself
 
         Returns:
-            A list containing all leaf nodes that descend from the current node and the current node if it is a leaf
+            A list containing all leaf nodes that descend from the current node
         """
 
-        if self.node_type == PixelNodeType.LEAF:
-            return [self]
-
         leaf_descendants = []
-        for child in self.children:
-            leaf_descendants += child.get_all_leaf_descendants()
+        self._add_all_leaf_descendants_rec(leaf_descendants)
         return leaf_descendants
+
+    def _add_all_leaf_descendants_rec(self, leaf_descendants: List[PixelNode]):
+        """Recursively add all leaf descendants to list
+
+        list must be created outside function, done for efficiency vs adding lists
+        """
+        if self.node_type == PixelNodeType.LEAF:
+            leaf_descendants.append(self)
+
+        for child in self.children:
+            child._add_all_leaf_descendants_rec(leaf_descendants)

--- a/src/hipscat/catalog/pixel_node.py
+++ b/src/hipscat/catalog/pixel_node.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import List
+
+from hipscat.catalog.pixel_node_type import PixelNodeType
+
+
+class PixelNode:
+    """A node in the HIPSCat quadtree of HEALPix pixels
+
+    Attributes:
+        hp_order: HEALPix order of the pixel
+        hp_pixel: HEALPix pixel number
+        node_type: If the node is a leaf, root, or inner type
+        parent: The parent pixel node in the tree
+        children: The child nodes of the pixel
+
+    """
+
+    def __init__(self,
+                 hp_order: int | None,
+                 hp_pixel: int | None,
+                 node_type: PixelNodeType,
+                 parent: PixelNode | None = None,
+                 children: List[PixelNode] = None):
+        """Inits PixelNode with its attributes
+
+        Raises:
+            ValueError: Invalid arguments for the specified pixel type
+        """
+
+        if node_type == PixelNodeType.ROOT and parent is not None:
+            raise ValueError("Root node cannot have a parent")
+
+        if node_type == PixelNodeType.INNER or node_type == PixelNodeType.LEAF:
+            if parent is None:
+                raise ValueError("Inner and leaf nodes must have a parent")
+            if hp_pixel is None or hp_order is None:
+                raise ValueError("Inner and leaf nodes must have an order and pixel number")
+
+        if children is None:
+            children = []
+
+        self.hp_order = hp_order
+        self.hp_pixel = hp_pixel
+        self.node_type = node_type
+        self.parent = parent
+        self.children = children
+
+        if self.parent is not None:
+            self.parent.add_child_node(self)
+
+    def add_child_node(self, child: PixelNode):
+        """Adds a child node to the node
+
+        Args:
+            child: child to add
+        """
+        self.children.append(child)
+
+    def get_all_leaf_descendants(self) -> List[PixelNode]:
+        """Gets all descendant nodes that are leaf nodes.
+
+        Leafs nodes correspond to pixels that have data files containing astronomical objects, so this method is used
+        to get the files containing all astronomical objects within the pixel
+
+        This function called on a leaf node returns a list including the node itself
+
+        Returns:
+            A list containing all leaf nodes that descend from the current node and the current node if it is a leaf
+        """
+
+        if self.node_type == PixelNodeType.LEAF:
+            return [self]
+
+        leaf_descendants = []
+        for child in self.children:
+            leaf_descendants += child.get_all_leaf_descendants()
+        return leaf_descendants

--- a/src/hipscat/catalog/pixel_node_type.py
+++ b/src/hipscat/catalog/pixel_node_type.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class PixelNodeType(Enum):
+
+    ROOT = 0
+    INNER = 1
+    LEAF = 2

--- a/tests/hipscat/catalog/conftest.py
+++ b/tests/hipscat/catalog/conftest.py
@@ -7,8 +7,8 @@ from hipscat.catalog.pixel_node_type import PixelNodeType
 @pytest.fixture
 def root_pixel_node_data():
     return {
-        "hp_order": None,
-        "hp_pixel": None,
+        "hp_order": -1,
+        "hp_pixel": -1,
         "node_type": PixelNodeType.ROOT,
         "parent": None,
         "children": None,
@@ -16,12 +16,8 @@ def root_pixel_node_data():
 
 
 @pytest.fixture
-def root_pixel_node():
-    return PixelNode(
-        None,
-        None,
-        PixelNodeType.ROOT,
-    )
+def root_pixel_node(root_pixel_node_data):
+    return PixelNode(**root_pixel_node_data)
 
 
 @pytest.fixture
@@ -43,8 +39,8 @@ def inner_pixel_node(inner_pixel_node_data):
 @pytest.fixture
 def leaf_pixel_node_data(inner_pixel_node):
     return {
-        "hp_order": 0,
-        "hp_pixel": 1,
+        "hp_order": 1,
+        "hp_pixel": 12,
         "node_type": PixelNodeType.LEAF,
         "parent": inner_pixel_node,
         "children": None,

--- a/tests/hipscat/catalog/conftest.py
+++ b/tests/hipscat/catalog/conftest.py
@@ -25,11 +25,32 @@ def root_pixel_node():
 
 
 @pytest.fixture
-def leaf_pixel_node_data(root_pixel_node):
+def inner_pixel_node_data(root_pixel_node):
+    return {
+        "hp_order": 0,
+        "hp_pixel": 1,
+        "node_type": PixelNodeType.INNER,
+        "parent": root_pixel_node,
+        "children": None,
+    }
+
+
+@pytest.fixture
+def inner_pixel_node(inner_pixel_node_data):
+    return PixelNode(**inner_pixel_node_data)
+
+
+@pytest.fixture
+def leaf_pixel_node_data(inner_pixel_node):
     return {
         "hp_order": 0,
         "hp_pixel": 1,
         "node_type": PixelNodeType.LEAF,
-        "parent": root_pixel_node,
+        "parent": inner_pixel_node,
         "children": None,
     }
+
+
+@pytest.fixture
+def leaf_pixel_node(leaf_pixel_node_data):
+    return PixelNode(**leaf_pixel_node_data)

--- a/tests/hipscat/catalog/test_pixel_node.py
+++ b/tests/hipscat/catalog/test_pixel_node.py
@@ -1,0 +1,30 @@
+import pytest
+
+from hipscat.catalog.pixel_node import PixelNode
+
+
+def check_node_data_correct(node, node_dict):
+    assert node.hp_order == node_dict["hp_order"]
+    assert node.hp_pixel == node_dict["hp_pixel"]
+    assert node.node_type == node_dict["node_type"]
+    assert node.parent == node_dict["parent"]
+
+
+def test_create_root_node_correct(root_pixel_node_data):
+    root_node = PixelNode(**root_pixel_node_data)
+    assert root_node
+    check_node_data_correct(root_node, root_pixel_node_data)
+
+
+def test_create_root_node_with_parent_raises_error(root_pixel_node, root_pixel_node_data):
+    with pytest.raises(ValueError):
+        root_pixel_node_data["parent"] = root_pixel_node
+        PixelNode(**root_pixel_node_data)
+
+
+def test_create_leaf_node(leaf_pixel_node_data, root_pixel_node):
+    leaf_node = PixelNode(**leaf_pixel_node_data)
+    assert leaf_node
+    check_node_data_correct(leaf_node, leaf_pixel_node_data)
+    assert len(root_pixel_node.children) == 1
+    assert leaf_node in root_pixel_node.children

--- a/tests/hipscat/catalog/test_pixel_node.py
+++ b/tests/hipscat/catalog/test_pixel_node.py
@@ -10,7 +10,7 @@ def check_node_data_correct(node, node_dict):
     assert node.parent == node_dict["parent"]
 
 
-def test_create_root_node_correct(root_pixel_node_data):
+def test_create_root_node(root_pixel_node_data):
     root_node = PixelNode(**root_pixel_node_data)
     assert root_node
     check_node_data_correct(root_node, root_pixel_node_data)
@@ -22,9 +22,55 @@ def test_create_root_node_with_parent_raises_error(root_pixel_node, root_pixel_n
         PixelNode(**root_pixel_node_data)
 
 
-def test_create_leaf_node(leaf_pixel_node_data, root_pixel_node):
+def test_create_inner_node(inner_pixel_node_data, root_pixel_node):
+    leaf_node = PixelNode(**inner_pixel_node_data)
+    assert leaf_node
+    check_node_data_correct(leaf_node, inner_pixel_node_data)
+    assert len(root_pixel_node.children) == 1
+    assert leaf_node in root_pixel_node.children
+
+
+def test_create_inner_node_with_no_parent_raises_error(inner_pixel_node_data):
+    with pytest.raises(ValueError):
+        inner_pixel_node_data["parent"] = None
+        PixelNode(**inner_pixel_node_data)
+
+
+def test_create_leaf_node(leaf_pixel_node_data, inner_pixel_node):
     leaf_node = PixelNode(**leaf_pixel_node_data)
     assert leaf_node
     check_node_data_correct(leaf_node, leaf_pixel_node_data)
-    assert len(root_pixel_node.children) == 1
-    assert leaf_node in root_pixel_node.children
+    assert len(inner_pixel_node.children) == 1
+    assert leaf_node in inner_pixel_node.children
+
+
+def test_create_leaf_node_with_no_parent_raises_error(leaf_pixel_node_data):
+    with pytest.raises(ValueError):
+        leaf_pixel_node_data["parent"] = None
+        PixelNode(**leaf_pixel_node_data)
+
+
+def test_create_leaf_node_with_no_hp_order_raises_error(leaf_pixel_node_data):
+    with pytest.raises(ValueError):
+        leaf_pixel_node_data["hp_order"] = None
+        PixelNode(**leaf_pixel_node_data)
+
+
+def test_create_leaf_node_with_no_hp_pixel_raises_error(leaf_pixel_node_data):
+    with pytest.raises(ValueError):
+        leaf_pixel_node_data["hp_pixel"] = None
+        PixelNode(**leaf_pixel_node_data)
+
+
+def test_get_leaf_descendants_with_leaf_node(leaf_pixel_node):
+    assert leaf_pixel_node.get_all_leaf_descendants() == [leaf_pixel_node]
+
+
+def test_get_leaf_descendants_with_root_node(root_pixel_node, leaf_pixel_node):
+    assert root_pixel_node.get_all_leaf_descendants() == [leaf_pixel_node]
+
+
+def test_get_leaf_descendants_with_multiple_leafs(root_pixel_node, leaf_pixel_node, leaf_pixel_node_data):
+    leaf_pixel_node_data["hp_pixel"] += 1
+    second_leaf = PixelNode(**leaf_pixel_node_data)
+    assert root_pixel_node.get_all_leaf_descendants() == [leaf_pixel_node, second_leaf]

--- a/tests/hipscat/catalog/test_pixel_node.py
+++ b/tests/hipscat/catalog/test_pixel_node.py
@@ -22,6 +22,12 @@ def test_create_root_node_with_parent_raises_error(root_pixel_node, root_pixel_n
         PixelNode(**root_pixel_node_data)
 
 
+def test_create_root_node_with_wrong_order_raises_error(root_pixel_node, root_pixel_node_data):
+    with pytest.raises(ValueError):
+        root_pixel_node_data["hp_order"] = 1
+        PixelNode(**root_pixel_node_data)
+
+
 def test_create_inner_node(inner_pixel_node_data, root_pixel_node):
     leaf_node = PixelNode(**inner_pixel_node_data)
     assert leaf_node
@@ -50,15 +56,63 @@ def test_create_leaf_node_with_no_parent_raises_error(leaf_pixel_node_data):
         PixelNode(**leaf_pixel_node_data)
 
 
-def test_create_leaf_node_with_no_hp_order_raises_error(leaf_pixel_node_data):
+def test_create_leaf_node_with_negative_hp_order_raises_error(leaf_pixel_node_data):
     with pytest.raises(ValueError):
-        leaf_pixel_node_data["hp_order"] = None
+        leaf_pixel_node_data["hp_order"] = -1
         PixelNode(**leaf_pixel_node_data)
 
 
-def test_create_leaf_node_with_no_hp_pixel_raises_error(leaf_pixel_node_data):
+def test_create_leaf_node_with_negative_hp_pixel_raises_error(leaf_pixel_node_data):
     with pytest.raises(ValueError):
-        leaf_pixel_node_data["hp_pixel"] = None
+        leaf_pixel_node_data["hp_pixel"] = -1
+        PixelNode(**leaf_pixel_node_data)
+
+
+def test_create_node_with_wrong_order_parent_raises_error(leaf_pixel_node_data, root_pixel_node):
+    with pytest.raises(ValueError):
+        leaf_pixel_node_data["parent"] = root_pixel_node
+        PixelNode(**leaf_pixel_node_data)
+
+
+def test_add_child_node_with_wrong_child_parent_raises_error(leaf_pixel_node, root_pixel_node):
+    with pytest.raises(ValueError):
+        root_pixel_node.add_child_node(leaf_pixel_node)
+
+
+def test_add_max_children_to_root_node(root_pixel_node, inner_pixel_node_data):
+    inner_nodes = []
+    for _ in range(12):
+        inner_pixel_node_data["hp_pixel"] += 1
+        inner_nodes.append(PixelNode(**inner_pixel_node_data))
+
+
+def test_add_too_many_children_to_root_node_fails(root_pixel_node, inner_pixel_node_data):
+    with pytest.raises(OverflowError):
+        inner_nodes = []
+        for _ in range(13):
+            inner_pixel_node_data["hp_pixel"] += 1
+            inner_nodes.append(PixelNode(**inner_pixel_node_data))
+
+
+def test_add_max_children_to_inner_node(inner_pixel_node, leaf_pixel_node_data):
+    leaf_nodes = []
+    for _ in range(4):
+        leaf_pixel_node_data["hp_pixel"] += 1
+        leaf_nodes.append(PixelNode(**leaf_pixel_node_data))
+
+
+def test_add_too_many_children_to_inner_node_fails(inner_pixel_node, leaf_pixel_node_data):
+    with pytest.raises(OverflowError):
+        leaf_nodes = []
+        for _ in range(5):
+            leaf_pixel_node_data["hp_pixel"] += 1
+            leaf_nodes.append(PixelNode(**leaf_pixel_node_data))
+
+
+def test_add_child_to_leaf_node_fails(leaf_pixel_node, leaf_pixel_node_data):
+    with pytest.raises(OverflowError):
+        leaf_pixel_node_data["hp_order"] = leaf_pixel_node.hp_order + 1
+        leaf_pixel_node_data["parent"] = leaf_pixel_node
         PixelNode(**leaf_pixel_node_data)
 
 

--- a/tests/hipscat/conftest.py
+++ b/tests/hipscat/conftest.py
@@ -1,0 +1,35 @@
+import pytest
+
+from hipscat.catalog.pixel_node import PixelNode
+from hipscat.catalog.pixel_node_type import PixelNodeType
+
+
+@pytest.fixture
+def root_pixel_node_data():
+    return {
+        "hp_order": None,
+        "hp_pixel": None,
+        "node_type": PixelNodeType.ROOT,
+        "parent": None,
+        "children": None,
+    }
+
+
+@pytest.fixture
+def root_pixel_node():
+    return PixelNode(
+        None,
+        None,
+        PixelNodeType.ROOT,
+    )
+
+
+@pytest.fixture
+def leaf_pixel_node_data(root_pixel_node):
+    return {
+        "hp_order": 0,
+        "hp_pixel": 1,
+        "node_type": PixelNodeType.LEAF,
+        "parent": root_pixel_node,
+        "children": None,
+    }


### PR DESCRIPTION
To be able to more efficiently work with hipscat pixels, this class can be used to construct and navigate through a sparse quad tree representation of hipscat data.

- Adds PixelNode class to be used in creating the pixel tree
- Unit tests for the class
- pytest `conftest.py` file with fixtures for creating test data and objects