### PR TITLE
Readme healpy/mac warning and line width adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ pip install '.[dev]'
 ```
 (Make sure to include the single quotes)
 
-### Installing healpy on a Mac
+### Installing healpy on Mac
 Native prebuilt binaries for healpy on Apple Silicon Macs [do not yet exist](https://healpy.readthedocs.io/en/latest/install.html#binary-installation-with-pip-recommended-for-most-other-python-users), so you may need to run 
 ```bash
 $ conda install healpy

--- a/README.md
+++ b/README.md
@@ -35,25 +35,27 @@ __ /path/to/catalogs/<catalog_name>/
 
 ## Installation
 
-
 ```bash
 $ git clone https://github.com/astronomy-commons/hipscat
 $ cd hipscat
 $ pip install -e .
 ```
 
-### Installing dev dependencies on Mac
+## Installation (Macs)
+
+Native prebuilt binaries for healpy on Apple Silicon Macs [do not yet exist](https://healpy.readthedocs.io/en/latest/install.html#binary-installation-with-pip-recommended-for-most-other-python-users), 
+so it's recommended to install via conda before proceeding to hipscat.
+```bash
+$ conda config --add channels conda-forge
+$ conda install healpy
+$ git clone https://github.com/astronomy-commons/hipscat
+$ cd hipscat
+$ pip install -e .
+``` 
+
+#### Installing dev dependencies
 
 ```bash
 $ pip install '.[dev]'
 ```
 (Make sure to include the single quotes)
-
-### Installing healpy on Mac
-Native prebuilt binaries for healpy on Apple Silicon Macs 
-[do not yet exist](https://healpy.readthedocs.io/en/latest/install.html#binary-installation-with-pip-recommended-for-most-other-python-users), 
-so you may need to run 
-```bash
-$ conda install healpy
-``` 
-before installing hipscat.

--- a/README.md
+++ b/README.md
@@ -2,17 +2,24 @@
 
 **Hierarchical Progressive Survey Catalog**
 
-A HiPSCat catalog is a partitioning of objects on a sphere. Its purpose is for storing data from large astronomy surveys, but could probably be used for other use cases where you have large data with some spherical properties.
+A HiPSCat catalog is a partitioning of objects on a sphere. Its purpose is for 
+storing data from large astronomy surveys, but could probably be used for other 
+use cases where you have large data with some spherical properties.
 
 ## Partitioning Scheme
 
-We use healpix (Hierarchical Equal Area isoLatitude Pixelization [[more](https://healpix.jpl.nasa.gov/)]) for the spherical pixelation, and adaptively size the partitions based on the number of objects.
+We use healpix (Hierarchical Equal Area isoLatitude Pixelization 
+[[more](https://healpix.jpl.nasa.gov/)]) for the spherical pixelation, and 
+adaptively size the partitions based on the number of objects.
 
-In areas of the sky with more objects, we use smaller pixels, so that all the resulting pixels should contain similar counts of objects (within an order of magnitude).
+In areas of the sky with more objects, we use smaller pixels, so that all the 
+resulting pixels should contain similar counts of objects (within an order of 
+magnitude).
 
 ## File structure
 
-The catalog reader expects to find files according to the following partitioned structure:
+The catalog reader expects to find files according to the following partitioned 
+structure:
 
 ```
 __ /path/to/catalogs/<catalog_name>/
@@ -43,7 +50,9 @@ $ pip install '.[dev]'
 (Make sure to include the single quotes)
 
 ### Installing healpy on Mac
-Native prebuilt binaries for healpy on Apple Silicon Macs [do not yet exist](https://healpy.readthedocs.io/en/latest/install.html#binary-installation-with-pip-recommended-for-most-other-python-users), so you may need to run 
+Native prebuilt binaries for healpy on Apple Silicon Macs 
+[do not yet exist](https://healpy.readthedocs.io/en/latest/install.html#binary-installation-with-pip-recommended-for-most-other-python-users), 
+so you may need to run 
 ```bash
 $ conda install healpy
 ``` 

--- a/README.md
+++ b/README.md
@@ -41,3 +41,10 @@ $ pip install -e .
 $ pip install '.[dev]'
 ```
 (Make sure to include the single quotes)
+
+### Installing healpy on a Mac
+Native prebuilt binaries for healpy on Apple Silicon Macs [do not yet exist](https://healpy.readthedocs.io/en/latest/install.html#binary-installation-with-pip-recommended-for-most-other-python-users), so you may need to run 
+```bash
+$ conda install healpy
+``` 
+before installing hipscat.

--- a/src/hipscat/pixel_math/README.md
+++ b/src/hipscat/pixel_math/README.md
@@ -2,7 +2,11 @@
 A reference document for the various utility functions of `hipscat/pixel_math`.
 
 ## Pixel Margins
-The functions made to find the pixels that make up the border region of a given healpixel. Primarly used as a way to speed up the neighbor/margin caching code for [hipscat-import](https://github.com/astronomy-commons/hipscat-import/). Code originally created by Mario Juric for HIPS, found [here](https://github.com/mjuric/HIPS/blob/feature/multiprocess/hipscat/healpix.py).
+The functions made to find the pixels that make up the border region of a given 
+healpixel. Primarly used as a way to speed up the neighbor/margin caching code 
+for [hipscat-import](https://github.com/astronomy-commons/hipscat-import/). Code 
+originally created by Mario Juric for HIPS, found 
+[here](https://github.com/mjuric/HIPS/blob/feature/multiprocess/hipscat/healpix.py).
 
 ### get_edge
 Given a pixel pix at some order, return all
@@ -58,9 +62,9 @@ This can be compactly written as:
 ```
 
 with i, j, k, ... being indices whose choice specifies which edge we get.
-For example iterating through, i = {0, 1}, j = {0, 1}, k = {0, 1} generates indices
-for the 8 pixels of the south-east edge for 3 subdivisions. Similarly, for
-the north-west edge the index values would loop through {2, 3}, etc.
+For example iterating through, i = {0, 1}, j = {0, 1}, k = {0, 1} generates 
+indices for the 8 pixels of the south-east edge for 3 subdivisions. Similarly, 
+for the north-west edge the index values would loop through {2, 3}, etc.
 
 This can be expanded as:
 


### PR DESCRIPTION
I was unable to run `pip install -e .` on my Mac without healpy throwing errors, so I added a heads up to the installation section.

The pixel math readme was keeping to line widths < 100 characters (but mostly also < 80), except the first section. Assuming this to be the desired style, I readjusted the beginning, then went over the main readme as well.