### PR TITLE
Refactor IO to IO layer

### DIFF
--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -4,13 +4,16 @@ import json
 import os
 
 from hipscat.catalog.partition_info import PartitionInfo
+from hipscat.io import file_io, paths
+from hipscat.io.paths import get_catalog_info_pointer
 
 
 class Catalog:
     """Container class for catalog metadata"""
 
-    def __init__(self, catalog_path=None):
+    def __init__(self, catalog_path: str = None) -> None:
         self.catalog_path = catalog_path
+        self.catalog_base_dir = file_io.get_file_pointer_from_path(catalog_path)
         self.metadata_keywords = None
 
         self.partition_info = None
@@ -20,18 +23,17 @@ class Catalog:
         self._initialize_metadata()
 
     def _initialize_metadata(self):
-        if not os.path.exists(self.catalog_path):
-            raise FileNotFoundError(f"No directory exists at {self.catalog_path}")
-        metadata_filename = os.path.join(self.catalog_path, "catalog_info.json")
-        if not os.path.exists(metadata_filename):
+        if not file_io.does_file_or_directory_exist(self.catalog_base_dir):
+            raise FileNotFoundError(f"No directory exists at {str(self.catalog_base_dir)}")
+        catalog_info_file = paths.get_catalog_info_pointer(self.catalog_base_dir)
+        if not file_io.does_file_or_directory_exist(catalog_info_file):
             raise FileNotFoundError(
-                f"No catalog info found where expected: {metadata_filename}"
+                f"No catalog info found where expected: {str(catalog_info_file)}"
             )
 
-        with open(metadata_filename, "r", encoding="utf-8") as metadata_info:
-            self.metadata_keywords = json.load(metadata_info)
+        self.metadata_keywords = file_io.load_json_file(catalog_info_file)
         self.catalog_name = self.metadata_keywords["catalog_name"]
-        self.partition_info = PartitionInfo(self.catalog_path)
+        self.partition_info = PartitionInfo(self.catalog_base_dir)
 
     def get_pixels(self):
         """Get all healpix pixels that are contained in the catalog

--- a/src/hipscat/catalog/catalog_parameters.py
+++ b/src/hipscat/catalog/catalog_parameters.py
@@ -3,6 +3,8 @@
 import os
 from typing import List
 
+from hipscat.io import file_io
+
 
 # pylint: disable=too-many-instance-attributes
 class CatalogParameters:
@@ -25,8 +27,10 @@ class CatalogParameters:
         self.input_format = input_format
         self.input_paths = input_paths
         self.output_path = output_path
-        self.catalog_path = os.path.join(output_path, catalog_name)
-        os.makedirs(self.catalog_path, exist_ok=True)
+        output_path_pointer = file_io.get_file_pointer_from_path(self.output_path)
+        self.catalog_base_dir = file_io.append_paths_to_pointer(output_path_pointer, self.catalog_name)
+        self.catalog_path = str(self.catalog_base_dir)
+        file_io.make_directory(self.catalog_base_dir, exist_ok=True)
 
         self.epoch = epoch
         self.ra_column = ra_column

--- a/src/hipscat/catalog/partition_info.py
+++ b/src/hipscat/catalog/partition_info.py
@@ -4,7 +4,7 @@ import os
 
 import pandas as pd
 
-from hipscat.io import paths
+from hipscat.io import paths, file_io
 
 
 class PartitionInfo:
@@ -14,16 +14,16 @@ class PartitionInfo:
     METADATA_DIR_COLUMN_NAME = "Dir"
     METADATA_PIXEL_COLUMN_NAME = "Npix"
 
-    def __init__(self, catalog_path=None):
-        self.catalog_path = catalog_path
+    def __init__(self, catalog_base_dir: file_io.FilePointer) -> None:
+        self.catalog_base_dir = catalog_base_dir
 
-        partition_info_filename = os.path.join(self.catalog_path, "partition_info.csv")
-        if not os.path.exists(partition_info_filename):
+        partition_info_pointer = paths.get_partition_info_pointer(self.catalog_base_dir)
+        if not file_io.does_file_or_directory_exist(partition_info_pointer):
             raise FileNotFoundError(
-                f"No partition info found where expected: {partition_info_filename}"
+                f"No partition info found where expected: {str(partition_info_pointer)}"
             )
 
-        self.data_frame = pd.read_csv(partition_info_filename)
+        self.data_frame = file_io.load_csv_to_pandas(partition_info_pointer)
 
     def get_file_names(self):
         """Get file handles for all partition files in the catalog
@@ -35,7 +35,7 @@ class PartitionInfo:
         for _, partition in self.data_frame.iterrows():
             file_names.append(
                 paths.pixel_catalog_file(
-                    self.catalog_path,
+                    self.catalog_base_dir,
                     partition[self.METADATA_ORDER_COLUMN_NAME],
                     partition[self.METADATA_PIXEL_COLUMN_NAME],
                 )

--- a/src/hipscat/io/file_io/__init__.py
+++ b/src/hipscat/io/file_io/__init__.py
@@ -1,0 +1,2 @@
+from .file_io import *
+from .file_pointers import *

--- a/src/hipscat/io/file_io/file_io.py
+++ b/src/hipscat/io/file_io/file_io.py
@@ -1,0 +1,29 @@
+import json
+import os
+
+import pandas as pd
+
+from hipscat.io.file_io.file_pointers import FilePointer
+
+
+def make_directory(file_pointer: FilePointer, exist_ok=False):
+    os.makedirs(file_pointer, exist_ok=exist_ok)
+
+
+def write_string_to_file(file_pointer: FilePointer, json_string: str, encoding: str="utf-8"):
+    with open(file_pointer, "w", encoding=encoding) as file:
+        file.write(json_string + "\n")
+
+
+def load_json_file(file_pointer: FilePointer, encoding: str= "utf-8") -> dict:
+    with open(file_pointer, "r", encoding=encoding) as json_file:
+        json_dict = json.load(json_file)
+    return json_dict
+
+
+def load_csv_to_pandas(file_pointer: FilePointer, **kwargs):
+    return pd.read_csv(file_pointer, **kwargs)
+
+
+def write_dataframe_to_csv(dataframe: pd.DataFrame, file_pointer: FilePointer, **kwargs):
+    dataframe.to_csv(file_pointer, **kwargs)

--- a/src/hipscat/io/file_io/file_io.py
+++ b/src/hipscat/io/file_io/file_io.py
@@ -6,24 +6,65 @@ import pandas as pd
 from hipscat.io.file_io.file_pointers import FilePointer
 
 
-def make_directory(file_pointer: FilePointer, exist_ok=False):
+def make_directory(file_pointer: FilePointer, exist_ok: bool=False):
+    """Make a directory at a given file pointer
+
+    Will raise an error if a directory already exists, unless `exist_ok` is True in which case
+    any existing directories will be left unmodified
+
+    Args:
+        file_pointer: location in file system to make directory
+        exist_ok: Default False. If false will raise error if directory exists. It true existing
+        directories will be ignored and not modified
+
+    Raises:
+        OSError
+    """
     os.makedirs(file_pointer, exist_ok=exist_ok)
 
 
-def write_string_to_file(file_pointer: FilePointer, json_string: str, encoding: str="utf-8"):
+def write_string_to_file(file_pointer: FilePointer, string: str, encoding: str = "utf-8"):
+    """Write a string to a text file
+
+    Args:
+        file_pointer: file location to write file to
+        string: string to write to file
+        encoding: Default: 'utf-8', encoding method to write to file with
+    """
     with open(file_pointer, "w", encoding=encoding) as file:
-        file.write(json_string + "\n")
+        file.write(string + "\n")
 
 
-def load_json_file(file_pointer: FilePointer, encoding: str= "utf-8") -> dict:
+def load_json_file(file_pointer: FilePointer, encoding: str = "utf-8") -> dict:
+    """Load a json file to a dictionary
+
+    Args:
+        file_pointer: location of file to read
+        encoding: string encoding method used by the file
+
+    """
+    json_dict = None
     with open(file_pointer, "r", encoding=encoding) as json_file:
         json_dict = json.load(json_file)
     return json_dict
 
 
 def load_csv_to_pandas(file_pointer: FilePointer, **kwargs):
+    """Load a csv file to a pandas dataframe
+
+    Args:
+        file_pointer: location of csv file to load
+        **kwargs: arguments to pass to pandas `read_csv` loading method
+    """
     return pd.read_csv(file_pointer, **kwargs)
 
 
 def write_dataframe_to_csv(dataframe: pd.DataFrame, file_pointer: FilePointer, **kwargs):
+    """Write a pandas DataFrame to a CSV file
+
+    Args:
+        dataframe: DataFrame to write
+        file_pointer: location of file to write to
+        **kwargs: args to pass to pandas `to_csv` method
+    """
     dataframe.to_csv(file_pointer, **kwargs)

--- a/src/hipscat/io/file_io/file_pointers.py
+++ b/src/hipscat/io/file_io/file_pointers.py
@@ -1,0 +1,35 @@
+import os
+from typing import NewType
+
+FilePointer = NewType("FilePointer", str)
+
+
+def get_file_pointer_from_path(path: str) -> FilePointer:
+    """Returns a file pointer from a path string"""
+    return FilePointer(path)
+
+
+def append_paths_to_pointer(pointer: FilePointer, *paths: str) -> FilePointer:
+    """Append directory or file names to a specified file pointer.
+
+    Args:
+        pointer: `FilePointer` object to add path to
+        paths: any number of file or directory names to append to the pointer
+
+    Returns:
+        New file pointer to path given by joining given pointer and path names
+
+    """
+    return FilePointer(os.path.join(pointer, *paths))
+
+
+def does_file_or_directory_exist(pointer: FilePointer) -> bool:
+    """Checks if a file or directory exists for a given file pointer
+
+    Args:
+        pointer: File Pointer to check if file or directory exists at
+
+    Returns:
+        True if file or directory at `pointer` exists, False if not
+    """
+    return os.path.exists(pointer)

--- a/src/hipscat/io/paths.py
+++ b/src/hipscat/io/paths.py
@@ -9,6 +9,9 @@ PIXEL_DIRECTORY_PREFIX = "Npix"
 
 CATALOG_INFO_FILENAME = "catalog_info.json"
 PARTITION_INFO_FILENAME = "partition_info.csv"
+PROVENANCE_INFO_FILENAME = "provenance_info.json"
+PARQUET_METADATA_FILENAME = "_metadata"
+PARQUET_COMMON_METADATA_FILENAME = "_common_metadata"
 
 
 def pixel_directory(
@@ -85,8 +88,45 @@ def pixel_catalog_file(
 
 
 def get_catalog_info_pointer(catalog_base_dir: FilePointer) -> FilePointer:
+    """Get file pointer to `catalog_info.json` metadata file
+
+    Args:
+        catalog_base_dir: pointer to base catalog directory
+    """
     return append_paths_to_pointer(catalog_base_dir, CATALOG_INFO_FILENAME)
 
 
 def get_partition_info_pointer(catalog_base_dir: FilePointer) -> FilePointer:
+    """Get file pointer to `partition_info.csv` metadata file
+
+    Args:
+        catalog_base_dir: pointer to base catalog directory
+    """
     return append_paths_to_pointer(catalog_base_dir, PARTITION_INFO_FILENAME)
+
+
+def get_provenance_pointer(catalog_base_dir: FilePointer) -> FilePointer:
+    """Get file pointer to `provenance_info.json` metadata file
+
+    Args:
+        catalog_base_dir: pointer to base catalog directory
+    """
+    return append_paths_to_pointer(catalog_base_dir, PROVENANCE_INFO_FILENAME)
+
+
+def get_common_metadata_pointer(catalog_base_dir: FilePointer) -> FilePointer:
+    """Get file pointer to `_metadata.parquet` metadata file
+
+    Args:
+        catalog_base_dir: pointer to base catalog directory
+    """
+    return append_paths_to_pointer(catalog_base_dir, PARQUET_COMMON_METADATA_FILENAME)
+
+
+def get_parquet_metadata_pointer(catalog_base_dir: FilePointer) -> FilePointer:
+    """Get file pointer to `_common_metadata.parquet` metadata file
+
+    Args:
+        catalog_base_dir: pointer to base catalog directory
+    """
+    return append_paths_to_pointer(catalog_base_dir, PARQUET_METADATA_FILENAME)

--- a/src/hipscat/io/paths.py
+++ b/src/hipscat/io/paths.py
@@ -1,33 +1,40 @@
 """Methods for creating partitioned data paths"""
+from __future__ import annotations
 
-import os
+from hipscat.io.file_io.file_pointers import FilePointer, append_paths_to_pointer
 
 ORDER_DIRECTORY_PREFIX = "Norder"
 DIR_DIRECTORY_PREFIX = "Dir"
 PIXEL_DIRECTORY_PREFIX = "Npix"
 
+CATALOG_INFO_FILENAME = "catalog_info.json"
+PARTITION_INFO_FILENAME = "partition_info.csv"
+
 
 def pixel_directory(
-    catalog_path="", pixel_order=0, pixel_number=None, directory_number=None
-):
-    """Create path *string* for a pixel directory. This will not create the directory.
+        catalog_base_dir: FilePointer,
+        pixel_order: int,
+        pixel_number: int | None = None,
+        directory_number: int | None = None,
+) -> FilePointer:
+    """Create path pointer for a pixel directory. This will not create the directory.
 
     One of pixel_number or directory_number is required. The directory name will
     take the HiPS standard form of:
 
-        <catalog_path>/Norder=<pixel_order>/Dir=<directory number>
+        <catalog_base_path>/Norder=<pixel_order>/Dir=<directory number>
 
     Where the directory number is calculated using integer division as:
 
         (pixel_number/10000)*10000
 
     Args:
-        catalog_path (str): base directory of the catalog (includes catalog name)
+        catalog_base_dir (FilePointer): base directory of the catalog (includes catalog name)
         pixel_order (int): the healpix order of the pixel
         directory_number (int): directory number
         pixel_number (int): the healpix pixel
     Returns:
-        string directory name
+        FilePointer directory name
     """
     norder = int(pixel_order)
     if pixel_number is None and directory_number is None:
@@ -39,26 +46,28 @@ def pixel_directory(
     else:
         npix = int(pixel_number)
         ndir = int(npix / 10_000) * 10_000
-    return os.path.join(
-        catalog_path,
+    return append_paths_to_pointer(
+        catalog_base_dir,
         f"{ORDER_DIRECTORY_PREFIX}={norder}",
         f"{DIR_DIRECTORY_PREFIX}={ndir}",
     )
 
 
-def pixel_catalog_file(catalog_path="", pixel_order=0, pixel_number=0):
-    """Create path *string* for a pixel catalog file. This will not create the directory or file.
+def pixel_catalog_file(
+        catalog_base_dir: FilePointer, pixel_order: int, pixel_number: int
+) -> FilePointer:
+    """Create path *pointer* for a pixel catalog file. This will not create the directory or file.
 
     The catalog file name will take the HiPS standard form of:
 
-        <catalog_path>/Norder=<pixel_order>/Dir=<directory number>/Npix=<pixel_number>.parquet
+        <catalog_base_dir>/Norder=<pixel_order>/Dir=<directory number>/Npix=<pixel_number>.parquet
 
     Where the directory number is calculated using integer division as:
 
         (pixel_number/10000)*10000
 
     Args:
-        catalog_path (str): base directory of the catalog (includes catalog name)
+        catalog_base_dir (FilePointer): base directory of the catalog (includes catalog name)
         pixel_order (int): the healpix order of the pixel
         pixel_number (int): the healpix pixel
     Returns:
@@ -67,9 +76,17 @@ def pixel_catalog_file(catalog_path="", pixel_order=0, pixel_number=0):
     norder = int(pixel_order)
     npix = int(pixel_number)
     ndir = int(npix / 10_000) * 10_000
-    return os.path.join(
-        catalog_path,
+    return append_paths_to_pointer(
+        catalog_base_dir,
         f"{ORDER_DIRECTORY_PREFIX}={norder}",
         f"{DIR_DIRECTORY_PREFIX}={ndir}",
         f"{PIXEL_DIRECTORY_PREFIX}={npix}.parquet",
     )
+
+
+def get_catalog_info_pointer(catalog_base_dir: FilePointer) -> FilePointer:
+    return append_paths_to_pointer(catalog_base_dir, CATALOG_INFO_FILENAME)
+
+
+def get_partition_info_pointer(catalog_base_dir: FilePointer) -> FilePointer:
+    return append_paths_to_pointer(catalog_base_dir, PARTITION_INFO_FILENAME)

--- a/src/hipscat/io/write_metadata.py
+++ b/src/hipscat/io/write_metadata.py
@@ -12,9 +12,6 @@ import pyarrow.parquet as pq
 
 from hipscat.io import paths
 
-PROVENANCE_INFO_FILENAME = "provenance_info.json"
-PARQUET_METADATA_FILENAME = "_metadata"
-PARQUET_COMMON_METADATA_FILENAME = "_common_metadata"
 
 from hipscat.io import file_io, paths
 
@@ -89,8 +86,8 @@ def write_provenance_info(args, tool_args):
 
     metadata["tool_args"] = tool_args
 
-    metadata_filename = os.path.join(args.catalog_path, PROVENANCE_INFO_FILENAME)
-    write_json_file(metadata, metadata_filename)
+    metadata_pointer = paths.get_provenance_pointer(args.catalog_base_dir)
+    write_json_file(metadata, metadata_pointer)
 
 
 def write_partition_info(catalog_parameters, destination_pixel_map: dict):
@@ -177,8 +174,9 @@ def write_parquet_metadata(catalog_path):
     )
     subschema = subschema.remove(subschema.get_field_index(paths.DIR_DIRECTORY_PREFIX))
 
-    metadata_path = os.path.join(catalog_path, PARQUET_METADATA_FILENAME)
-    common_metadata_path = os.path.join(catalog_path, PARQUET_COMMON_METADATA_FILENAME)
+    catalog_base_dir = file_io.get_file_pointer_from_path(catalog_path)
+    metadata_path = paths.get_parquet_metadata_pointer(catalog_base_dir)
+    common_metadata_path = paths.get_common_metadata_pointer(catalog_base_dir)
 
     pq.write_metadata(subschema, metadata_path, metadata_collector=metadata_collector)
     pq.write_metadata(subschema, common_metadata_path)

--- a/src/hipscat/io/write_metadata.py
+++ b/src/hipscat/io/write_metadata.py
@@ -8,7 +8,6 @@ import numpy as np
 import pandas as pd
 from setuptools_scm import get_version
 
-from hipscat.catalog import CatalogParameters
 from hipscat.io import file_io, paths
 
 
@@ -33,7 +32,7 @@ def write_json_file(metadata_dictionary: dict, file_pointer: file_io.FilePointer
     file_io.write_string_to_file(file_pointer, dumped_metadata)
 
 
-def write_catalog_info(catalog_parameters: CatalogParameters, histogram: np.ndarray):
+def write_catalog_info(catalog_parameters, histogram: np.ndarray):
     """Write a catalog_info.json file with catalog metadata
 
     Args:
@@ -59,7 +58,7 @@ def write_catalog_info(catalog_parameters: CatalogParameters, histogram: np.ndar
     write_json_file(metadata, catalog_info_pointer)
 
 
-def write_partition_info(catalog_parameters: CatalogParameters, destination_pixel_map: dict):
+def write_partition_info(catalog_parameters, destination_pixel_map: dict):
     """Write all partition data to CSV file.
 
     Args:
@@ -78,7 +77,7 @@ def write_partition_info(catalog_parameters: CatalogParameters, destination_pixe
     file_io.write_dataframe_to_csv(data_frame, partition_info_pointer, index=False)
 
 
-def write_legacy_metadata(catalog_patameters: CatalogParameters, histogram: np.ndarray, pixel_map: np.ndarray):
+def write_legacy_metadata(catalog_patameters, histogram: np.ndarray, pixel_map: np.ndarray):
     """Write a <catalog_name>_meta.json with the format expected by the prototype catalog.
 
     Args:

--- a/tests/hipscat/io/file_io/test_file_io.py
+++ b/tests/hipscat/io/file_io/test_file_io.py
@@ -1,0 +1,76 @@
+import json
+import os.path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from hipscat.io.file_io import get_file_pointer_from_path, make_directory, write_string_to_file, \
+    load_json_file, load_csv_to_pandas, write_dataframe_to_csv
+
+
+def test_make_directory(tmp_path):
+    test_dir_path = os.path.join(tmp_path, "test_path")
+    assert not os.path.exists(test_dir_path)
+    test_dir_pointer = get_file_pointer_from_path(test_dir_path)
+    make_directory(test_dir_pointer)
+    assert os.path.exists(test_dir_path)
+
+
+def test_make_existing_directory_raises(tmp_path):
+    test_dir_path = os.path.join(tmp_path, "test_path")
+    os.makedirs(test_dir_path)
+    assert os.path.exists(test_dir_path)
+    test_dir_pointer = get_file_pointer_from_path(test_dir_path)
+    with pytest.raises(OSError):
+        make_directory(test_dir_pointer)
+
+
+def test_make_existing_directory_existok(tmp_path):
+    test_dir_path = os.path.join(tmp_path, "test_path")
+    os.makedirs(test_dir_path)
+    test_inner_dir_path = os.path.join(test_dir_path, "test_inner")
+    os.makedirs(test_inner_dir_path)
+    assert os.path.exists(test_dir_path)
+    assert os.path.exists(test_inner_dir_path)
+    test_dir_pointer = get_file_pointer_from_path(test_dir_path)
+    make_directory(test_dir_pointer, exist_ok=True)
+    assert os.path.exists(test_dir_path)
+    assert os.path.exists(test_inner_dir_path)
+
+
+def test_write_string_to_file(tmp_path):
+    test_file_path = os.path.join(tmp_path, "text_file.txt")
+    test_file_pointer = get_file_pointer_from_path(test_file_path)
+    test_string = "this is a test"
+    write_string_to_file(test_file_pointer, test_string, encoding="utf-8")
+    with open(test_file_path, 'r', encoding="utf-8") as file:
+        data = file.read().rstrip()
+        assert data == test_string
+
+
+def test_load_json(small_sky_dir):
+    catalog_info_path = os.path.join(small_sky_dir, "catalog_info.json")
+    json_dict = None
+    with open(catalog_info_path, "r", encoding="utf-8") as json_file:
+        json_dict = json.load(json_file)
+    catalog_info_pointer = get_file_pointer_from_path(catalog_info_path)
+    loaded_json_dict = load_json_file(catalog_info_pointer, encoding="utf-8")
+    assert loaded_json_dict == json_dict
+
+
+def test_load_csv_to_pandas(small_sky_dir):
+    partition_info_path = os.path.join(small_sky_dir, "partition_info.csv")
+    csv_df = pd.read_csv(partition_info_path)
+    partition_info_pointer = get_file_pointer_from_path(partition_info_path)
+    loaded_df = load_csv_to_pandas(partition_info_pointer)
+    pd.testing.assert_frame_equal(csv_df, loaded_df)
+
+
+def test_write_df_to_csv(tmp_path):
+    df = pd.DataFrame(np.random.randint(0,100,size=(100, 4)), columns=list('ABCD'))
+    test_file_path = os.path.join(tmp_path, "test.csv")
+    test_file_pointer = get_file_pointer_from_path(test_file_path)
+    write_dataframe_to_csv(df, test_file_pointer, index=False)
+    loaded_df = pd.read_csv(test_file_path)
+    pd.testing.assert_frame_equal(loaded_df, df)

--- a/tests/hipscat/io/file_io/test_file_pointers.py
+++ b/tests/hipscat/io/file_io/test_file_pointers.py
@@ -1,11 +1,29 @@
-from hipscat.io.file_io import get_file_pointer_from_path, does_file_or_directory_exist
+import os
+
+from hipscat.io.file_io import get_file_pointer_from_path, does_file_or_directory_exist, \
+    append_paths_to_pointer, FilePointer
+
+
+def test_get_pointer_from_path(tmp_path):
+    tmp_pointer = get_file_pointer_from_path(str(tmp_path))
+    assert str(tmp_pointer) == str(tmp_path)
 
 
 def test_file_or_dir_exist(small_sky_dir):
     small_sky_pointer = get_file_pointer_from_path(small_sky_dir)
     assert does_file_or_directory_exist(small_sky_pointer)
+    catalog_info_string = os.path.join(small_sky_dir, "catalog_info.json")
+    catalog_info_pointer = get_file_pointer_from_path(catalog_info_string)
+    assert does_file_or_directory_exist(catalog_info_pointer)
 
 
 def test_file_or_dir_exist_false(small_sky_dir):
     small_sky_pointer = get_file_pointer_from_path(small_sky_dir + "incorrect file")
     assert not does_file_or_directory_exist(small_sky_pointer)
+
+
+def test_append_paths_to_pointer(tmp_path):
+    test_paths = ["folder", "file.txt"]
+    test_path = os.path.join(tmp_path, *test_paths)
+    tmp_pointer = get_file_pointer_from_path(str(tmp_path))
+    assert append_paths_to_pointer(tmp_pointer, *test_paths) == test_path

--- a/tests/hipscat/io/file_io/test_file_pointers.py
+++ b/tests/hipscat/io/file_io/test_file_pointers.py
@@ -1,0 +1,11 @@
+from hipscat.io.file_io import get_file_pointer_from_path, does_file_or_directory_exist
+
+
+def test_file_or_dir_exist(small_sky_dir):
+    small_sky_pointer = get_file_pointer_from_path(small_sky_dir)
+    assert does_file_or_directory_exist(small_sky_pointer)
+
+
+def test_file_or_dir_exist_false(small_sky_dir):
+    small_sky_pointer = get_file_pointer_from_path(small_sky_dir + "incorrect file")
+    assert not does_file_or_directory_exist(small_sky_pointer)


### PR DESCRIPTION
To allow easy changing to a file system library like `fsspec` for use with multiple file systems, all IO is refactored to a package. 

A new `FilePointer` type is defined to represent the path to a file/folder. Currently this is a subtype of string, but it can be replaced by the type fsspec will use when that is integrated.

All paths are replaced with the equivalent file pointers, with methods for IO using these pointers written.