### PR TITLE
Add healpix pixel class

### DIFF
--- a/src/hipscat/pixel_math/healpix_pixel.py
+++ b/src/hipscat/pixel_math/healpix_pixel.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import hipscat.pixel_math.hipscat_id
+
+MAXIMUM_ORDER = hipscat.pixel_math.hipscat_id.HIPSCAT_ID_HEALPIX_ORDER
+
+
+@dataclass
+class HealpixPixel:
+    """A HEALPix pixel, represented by an order and pixel number in NESTED ordering scheme
+
+    see https://lambda.gsfc.nasa.gov/toolbox/pixelcoords.html for more information
+    """
+
+    order: int
+    pixel: int
+
+    def __post_init__(self) -> None:
+        """Initialize a HEALPix pixel
+        Args:
+            order: HEALPix order
+            pixel: HEALPix pixel number in NESTED ordering scheme
+        """
+        if self.order > MAXIMUM_ORDER:
+            raise ValueError(f"HEALPix order cannot be greater than {MAXIMUM_ORDER}")
+
+    def _key(self) -> tuple[int, int]:
+        """Returns tuple of order and pixel, for use in hashing and equality"""
+        return self.order, self.pixel
+
+    def __eq__(self, other: object) -> bool:
+        """Defines 2 pixels as equal if they have the same order and pixel"""
+        if not isinstance(other, HealpixPixel):
+            return False
+        return self._key() == other._key()
+
+    def __hash__(self) -> int:
+        """Hashes pixels by order and pixel, so equal pixel objects are looked up the same in
+        hashable data structures"""
+        return hash(self._key())
+
+    def __str__(self) -> str:
+        return f"Order: {self.order}, Pixel: {self.pixel}"
+
+    def __repr__(self):
+        return self.__str__()

--- a/tests/hipscat/pixel_math/test_healpix_pixel.py
+++ b/tests/hipscat/pixel_math/test_healpix_pixel.py
@@ -1,0 +1,31 @@
+import pytest
+
+from hipscat.pixel_math.healpix_pixel import HealpixPixel, MAXIMUM_ORDER
+
+
+def test_pixels_equal():
+    order = 3
+    pixel = 42
+    pix1 = HealpixPixel(order=order, pixel=pixel)
+    pix2 = HealpixPixel(order=order, pixel=pixel)
+    assert pix1 == pix2
+    assert pix1.order == pix2.order
+    assert pix1.pixel == pix2.pixel
+
+
+def test_order_greater_than_max_order_fails():
+    with pytest.raises(ValueError):
+        HealpixPixel(order=MAXIMUM_ORDER + 1, pixel=0)
+
+
+def test_equal_pixel_hash_equal():
+    order = 3
+    pixel = 42
+    test_string = "testing"
+    pix1 = HealpixPixel(order=order, pixel=pixel)
+    test_dict = {}
+    test_dict[pix1] = test_string
+    pix2 = HealpixPixel(order=order, pixel=pixel)
+    assert pix1 == pix2
+    assert pix2 in test_dict
+    assert test_dict[pix2] == test_string


### PR DESCRIPTION
Refactoring the `HealpixPixel` class moving from LSDB (where it was first added in astronomy-commons/lsdb#12)) to the hipscat library.

Used to reference to a HEALPix pixel instead of keeping an order and pixel number, with hashing based on these values to allow pixels to be used as dictionary and set keys.