### PR TITLE
add pytest-timeout to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "pre-commit", # Used to run checks before finalizing a git commit
     "pytest",
     "pytest-cov", # Used to report total code coverage
+    "pytest-timeout", # Used to test for code efficiency
     "sphinx==6.1.3", # Used to automatically generate documentation
     "sphinx_rtd_theme==1.2.0", # Used to render documentation
     "sphinx-autoapi==2.0.1", # Used to automatically generate api documentation


### PR DESCRIPTION
one of our [tests](https://github.com/astronomy-commons/hipscat/blob/main/tests/hipscat/pixel_math/test_hipscat_id.py#L70) uses `@pytest.mark.timeout`, which is only usable with the `pytest-timeout` plugin. however, this wasn't installed by default with the dev dependencies and it was giving a warning when running pytest.