### PR TITLE
fix for issue #93

### DIFF
--- a/src/hipscat/io/write_metadata.py
+++ b/src/hipscat/io/write_metadata.py
@@ -33,8 +33,8 @@ def write_catalog_info(catalog_parameters):
     metadata["catalog_name"] = catalog_parameters.catalog_name
     metadata["catalog_type"] = catalog_parameters.catalog_type
     metadata["epoch"] = catalog_parameters.epoch
-    metadata["ra_kw"] = catalog_parameters.ra_column
-    metadata["dec_kw"] = catalog_parameters.dec_column
+    metadata["ra_column"] = catalog_parameters.ra_column
+    metadata["dec_column"] = catalog_parameters.dec_column
     metadata["total_rows"] = catalog_parameters.total_rows
 
     catalog_info_pointer = paths.get_catalog_info_pointer(

--- a/tests/hipscat/io/test_write_metadata.py
+++ b/tests/hipscat/io/test_write_metadata.py
@@ -9,9 +9,9 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
-import hipscat.io.file_io as file_io
 import hipscat.io.write_metadata as io
 import hipscat.pixel_math as hist
+from hipscat.io import file_io
 from hipscat.pixel_math.healpix_pixel import HealpixPixel
 
 
@@ -51,8 +51,8 @@ def test_write_catalog_info(assert_text_file_matches, tmp_path, basic_catalog_in
         '    "catalog_name": "small_sky",',
         '    "catalog_type": "object",',
         '    "epoch": "J2000",',
-        '    "ra_kw": "ra",',
-        '    "dec_kw": "dec",',
+        '    "ra_column": "ra",',
+        '    "dec_column": "dec",',
         '    "total_rows": 131',
         "}",
     ]


### PR DESCRIPTION
closes #93 

small change to the naming of our `catalog_info.json` file that fixes a bug with loading in a catalog.

in `BaseCatalogInfo.read_from_metadata_file`, we scrape all the dataclass fields available to us and grab the values from the json file. however, in `CatalogInfo` the fields are named `ra_column` and `dec_column`, but within the json file they're called `ra_kw` and `dec_kw`. because of this cataloginfo will miss the actual column names and use the defaults `ra` and `dec` which can cause breaking changes.

we could instead change the `CatalogInfo` class to use `ra_kw` and `dec_kw` to avoid having to change the metadata file, but I personally prefer this option because it require less code changes (very few parts of the code directly access the metadata file whereas `CatalogInfo.[ra/dec]_column` is accessed quite a lot).

adding both sean and melissa to make sure I'm not missing something/seriously breaking the api! I've tested on hipscat-import and it doesn't seem to screw anything up.

