### PR TITLE
Implement a lowest order for histogram alignment

### DIFF
--- a/src/hipscat/pixel_math/partition_stats.py
+++ b/src/hipscat/pixel_math/partition_stats.py
@@ -56,7 +56,9 @@ def generate_histogram(
     return histogram_result
 
 
-def generate_alignment(histogram, highest_order=10, threshold=1_000_000):
+def generate_alignment(
+    histogram, highest_order=10, lowest_order=0, threshold=1_000_000
+):
     """Generate alignment from high order pixels to those of equal or lower order
 
     We may initially find healpix pixels at order 10, but after aggregating up to the pixel
@@ -67,7 +69,9 @@ def generate_alignment(histogram, highest_order=10, threshold=1_000_000):
     Args:
         histogram (:obj:`np.array`): one-dimensional numpy array of long integers where the
             value at each index corresponds to the number of objects found at the healpix pixel.
-        highest_order (int):  the highest healpix order (e.g. 0-10)
+        highest_order (int):  the highest healpix order (e.g. 5-10)
+        lowest_order (int): the lowest healpix order (e.g. 1-5). specifying a lowest order
+            constrains the partitioning  to prevent spatially large pixels.
         threshold (int): the maximum number of objects allowed in a single pixel
     Returns:
         one-dimensional numpy array of integer 3-tuples, where the value at each index corresponds
@@ -84,6 +88,8 @@ def generate_alignment(histogram, highest_order=10, threshold=1_000_000):
     """
     if len(histogram) != hp.order2npix(highest_order):
         raise ValueError("histogram is not the right size")
+    if lowest_order > highest_order:
+        raise ValueError("lowest_order should be less than highest_order")
     max_bin = np.amax(histogram)
     if max_bin > threshold:
         raise ValueError(f"single pixel count {max_bin} exceeds threshold {threshold}")
@@ -94,7 +100,7 @@ def generate_alignment(histogram, highest_order=10, threshold=1_000_000):
     nested_sums.append(histogram)
 
     # work backward - from highest order, fill in the sums of lower order pixels
-    for read_order in range(highest_order, 0, -1):
+    for read_order in range(highest_order, lowest_order, -1):
         parent_order = read_order - 1
         for index in range(0, len(nested_sums[read_order])):
             parent_pixel = index >> 2
@@ -105,7 +111,7 @@ def generate_alignment(histogram, highest_order=10, threshold=1_000_000):
         nested_alignment.append(np.full(hp.order2npix(i), None))
 
     # work forward - determine if we should map to a lower order pixel, this pixel, or keep looking.
-    for read_order in range(0, highest_order + 1):
+    for read_order in range(lowest_order, highest_order + 1):
         parent_order = read_order - 1
         for index in range(0, len(nested_sums[read_order])):
             parent_alignment = None
@@ -160,7 +166,7 @@ def generate_destination_pixel_map(histogram, pixel_map):
     return result
 
 
-def compute_pixel_map(histogram, highest_order=10, threshold=1_000_000):
+def compute_pixel_map(histogram, highest_order=10, lowest_order=0, threshold=1_000_000):
     # pylint: disable=too-many-locals
     """Generate alignment from high order pixels to those of equal or lower order
 
@@ -173,6 +179,8 @@ def compute_pixel_map(histogram, highest_order=10, threshold=1_000_000):
         histogram (:obj:`np.array`): one-dimensional numpy array of long integers where the
             value at each index corresponds to the number of objects found at the healpix pixel.
         highest_order (int):  the highest healpix order (e.g. 0-10)
+        lowest_order (int): the lowest healpix order (e.g. 1-5). specifying a lowest order
+            constrains the partitioning  to prevent spatially large pixels.
         threshold (int): the maximum number of objects allowed in a single pixel
     Returns:
         dictionary that maps the HealpixPixel (a pixel at destination order) to a tuple of
@@ -188,6 +196,8 @@ def compute_pixel_map(histogram, highest_order=10, threshold=1_000_000):
     """
     if len(histogram) != hp.order2npix(highest_order):
         raise ValueError("histogram is not the right size")
+    if lowest_order > highest_order:
+        raise ValueError("lowest_order should be less than highest_order")
     max_bin = np.amax(histogram)
     if max_bin > threshold:
         raise ValueError(f"single pixel count {max_bin} exceeds threshold {threshold}")
@@ -201,7 +211,7 @@ def compute_pixel_map(histogram, highest_order=10, threshold=1_000_000):
 
     ## Determine the highest order that does not exceed the threshold
     orders_at_threshold = [0 if 0 < k <= threshold else None for k in nested_sums[0]]
-    for order in range(1, highest_order + 1):
+    for order in range(lowest_order, highest_order + 1):
         new_orders_at_threshold = np.array(
             [order if 0 < k <= threshold else None for k in nested_sums[order]]
         )
@@ -263,7 +273,7 @@ def generate_constant_pixel_map(histogram, constant_healpix_order):
         The tuple contains the following:
 
         - 0 - the total number of rows found in this destination pixel, same as the origin bin
-        - 1 - the set of indexes in histogram for the pixels at the original healpix 
+        - 1 - the set of indexes in histogram for the pixels at the original healpix
           order, which will be a list containing only the origin pixel.
     Raises:
         ValueError: if the histogram is the wrong size

--- a/tests/hipscat/pixel_math/test_partition_stats.py
+++ b/tests/hipscat/pixel_math/test_partition_stats.py
@@ -38,12 +38,11 @@ def test_column_names_error():
         columns=["id", "ra_mean", "dec_mean"],
     )
 
-    with pytest.raises(ValueError) as error:
+    with pytest.raises(ValueError, match="Invalid column names"):
         hist.generate_histogram(
             data=data,
             highest_order=0,
         )
-        assert "Invalid column names" in error.value
 
 
 def test_column_names():
@@ -70,17 +69,24 @@ def test_column_names():
 def test_alignment_wrong_size():
     """Check that the method raises error when the input histogram is not the expected size."""
     initial_histogram = np.asarray([0, 0, 0, 0, 0, 0, 0, 0, 0, 131])
-    with pytest.raises(ValueError) as error:
-        hist.generate_alignment(initial_histogram, 0, 250)
-        assert "histogram is not the right size" == error.value
+    with pytest.raises(ValueError, match="histogram is not the right size"):
+        hist.generate_alignment(initial_histogram, highest_order=0, threshold=250)
 
 
 def test_alignment_exceeds_threshold_order0():
     """Check that the method raises error when some pixel exceeds the threshold."""
     initial_histogram = np.asarray([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 131])
-    with pytest.raises(ValueError) as error:
-        hist.generate_alignment(initial_histogram, 0, 20)
-        assert "exceeds threshold" in error.value
+    with pytest.raises(ValueError, match="exceeds threshold"):
+        hist.generate_alignment(initial_histogram, highest_order=0, threshold=20)
+
+
+def test_alignment_lowest_order_too_large():
+    """Check that the method raises error when some pixel exceeds the threshold."""
+    initial_histogram = hist.empty_histogram(1)
+    with pytest.raises(ValueError, match="lowest_order"):
+        hist.generate_alignment(
+            initial_histogram, highest_order=1, lowest_order=2, threshold=20
+        )
 
 
 def test_alignment_exceeds_threshold_order2():
@@ -88,15 +94,14 @@ def test_alignment_exceeds_threshold_order2():
     initial_histogram = hist.empty_histogram(2)
     filled_pixels = [4, 11, 14, 13, 5, 7, 8, 9, 11, 23, 4, 4, 17, 0, 1, 0]
     initial_histogram[176:] = filled_pixels[:]
-    with pytest.raises(ValueError) as error:
-        hist.generate_alignment(initial_histogram, 2, 20)
-        assert "exceeds threshold" in error.value
+    with pytest.raises(ValueError, match="exceeds threshold"):
+        hist.generate_alignment(initial_histogram, highest_order=2, threshold=20)
 
 
 def test_alignment_small_sky_order0():
     """Create alignment from small sky's distribution at order 0"""
     initial_histogram = np.asarray([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 131])
-    result = hist.generate_alignment(initial_histogram, 0, 250)
+    result = hist.generate_alignment(initial_histogram, highest_order=0, threshold=250)
 
     expected = np.full(12, None)
     expected[11] = (0, 11, 131)
@@ -109,7 +114,7 @@ def test_alignment_small_sky_order1():
     initial_histogram = hist.empty_histogram(1)
     filled_pixels = [42, 29, 42, 18]
     initial_histogram[44:] = filled_pixels[:]
-    result = hist.generate_alignment(initial_histogram, 1, 250)
+    result = hist.generate_alignment(initial_histogram, highest_order=1, threshold=250)
 
     expected = np.full(48, None)
     expected[44:] = [(0, 11, 131), (0, 11, 131), (0, 11, 131), (0, 11, 131)]
@@ -122,7 +127,7 @@ def test_alignment_small_sky_order2():
     initial_histogram = hist.empty_histogram(2)
     filled_pixels = [4, 11, 14, 13, 5, 7, 8, 9, 11, 23, 4, 4, 17, 0, 1, 0]
     initial_histogram[176:] = filled_pixels[:]
-    result = hist.generate_alignment(initial_histogram, 2, 250)
+    result = hist.generate_alignment(initial_histogram, highest_order=2, threshold=250)
 
     expected = np.full(hp.order2npix(2), None)
     tuples = [
@@ -151,10 +156,19 @@ def test_alignment_small_sky_order2():
 def test_alignment_even_sky():
     """Create alignment from an even distribution at order 8"""
     initial_histogram = np.full(hp.order2npix(8), 10)
-    result = hist.generate_alignment(initial_histogram, 8, 1_000)
+    result = hist.generate_alignment(
+        initial_histogram, highest_order=8, threshold=1_000
+    )
     # everything maps to order 5, given the density
     for mapping in result:
         assert mapping[0] == 5
+
+    result = hist.generate_alignment(
+        initial_histogram, highest_order=8, lowest_order=7, threshold=1_000
+    )
+    # everything maps to order 7 (would be 5, but lowest of 7 is enforced)
+    for mapping in result:
+        assert mapping[0] == 7
 
 
 def test_destination_pixel_map_order1():
@@ -198,6 +212,23 @@ def test_compute_pixel_map_order1():
     npt.assert_array_equal(result, expected)
 
 
+def test_compute_pixel_map_even_sky():
+    """Create alignment from an even distribution at order 8"""
+    initial_histogram = np.full(hp.order2npix(8), 10)
+    result = hist.compute_pixel_map(
+        initial_histogram, highest_order=8, threshold=1_000
+    )
+    # everything maps to order 5, given the density
+    for mapping in result:
+        assert mapping.order == 5
+
+    result = hist.compute_pixel_map(
+        initial_histogram, highest_order=8, lowest_order=7, threshold=1_000
+    )
+    # everything maps to order 7 (would be 5, but lowest of 7 is enforced)
+    for mapping in result:
+        assert mapping.order == 7
+
 def test_compute_pixel_map_invalid_inputs():
     """Create destination pixel map for small sky at order 1"""
 
@@ -206,14 +237,18 @@ def test_compute_pixel_map_invalid_inputs():
     initial_histogram[44:] = filled_pixels[:]
 
     ## Order doesn't match histogram length
-    with pytest.raises(ValueError) as length_error:
+    with pytest.raises(ValueError, match="histogram is not the right size"):
         hist.compute_pixel_map(initial_histogram, highest_order=2, threshold=150)
-        assert "histogram is not the right size" in length_error.value
 
     ## Some bins exceed threshold
-    with pytest.raises(ValueError) as threshold_error:
+    with pytest.raises(ValueError, match="exceeds threshold"):
         hist.compute_pixel_map(initial_histogram, highest_order=1, threshold=30)
-        assert "exceeds threshold" in threshold_error.value
+
+    ## lowest_order too large
+    with pytest.raises(ValueError, match="lowest_order"):
+        hist.compute_pixel_map(
+            initial_histogram, highest_order=1, lowest_order=2, threshold=30
+        )
 
 
 def test_generate_constant_pixel_map():
@@ -251,6 +286,5 @@ def test_generate_constant_pixel_map_invalid_inputs():
     initial_histogram[44:] = filled_pixels[:]
 
     ## Order doesn't match histogram length
-    with pytest.raises(ValueError) as length_error:
+    with pytest.raises(ValueError, match="histogram is not the right size"):
         hist.generate_constant_pixel_map(initial_histogram, constant_healpix_order=2)
-        assert "histogram is not the right size" in length_error.value


### PR DESCRIPTION
## Change Description

Add an option for a lowest healpix order for alignment/pixel map logic. This would be used to keep tiles spatially small, even when the object density is low. This is complimentary to the constant healpix order logic.

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists

### New Feature Checklist
- [x] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the tutorial to highlight my new feature (if appropriate)
- [x] I have added unit/End-to-End (E2E) test cases to cover my new feature