### PR TITLE
Add step to list dependencies.

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -31,6 +31,7 @@ jobs:
         pip install .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: List dependencies
+      run: |
         pip list
     - name: Run unit tests with pytest
       run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -30,6 +30,8 @@ jobs:
         pip install .
         pip install .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: List dependencies
+        pip list
     - name: Run unit tests with pytest
       run: |
         python -m pytest tests


### PR DESCRIPTION
This adds a new step to the smoke test to list ALL the dependencies and their versions. This should be easier to diff between successful and failing runs to determine which dependency has introduced a regression.