### PR TITLE
Addressing pylint findings in tests directory.

### DIFF
--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -503,7 +503,7 @@ ignore-imports=yes
 ignore-signatures=yes
 
 # Minimum lines number of a similarity.
-min-similarity-lines=4
+min-similarity-lines=6
 
 
 [SPELLING]

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -289,7 +289,8 @@ max-bool-expr=5
 max-branches=20
 
 # Maximum number of locals for function / method body.
-max-locals=15
+# We set this higher in tests to allow a more narrative style.
+max-locals=30
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7

--- a/tests/hipscat/catalog/association_catalog/test_association_catalog.py
+++ b/tests/hipscat/catalog/association_catalog/test_association_catalog.py
@@ -68,11 +68,7 @@ def test_empty_directory(tmp_path, association_catalog_info_data, association_ca
 
     ## catalog_info file exists - getting closer
     file_name = os.path.join(catalog_path, "catalog_info.json")
-    with open(
-        file_name,
-        "w",
-        encoding="utf-8",
-    ) as metadata_file:
+    with open(file_name, "w", encoding="utf-8") as metadata_file:
         metadata_file.write(json.dumps(association_catalog_info_data))
 
     with pytest.raises(FileNotFoundError):

--- a/tests/hipscat/catalog/dataset/test_base_catalog_info.py
+++ b/tests/hipscat/catalog/dataset/test_base_catalog_info.py
@@ -36,6 +36,6 @@ def test_str(base_catalog_info_data):
 def test_read_from_file(base_catalog_info_file, assert_catalog_info_matches_dict):
     base_cat_info_fp = file_io.get_file_pointer_from_path(base_catalog_info_file)
     catalog_info = BaseCatalogInfo.read_from_metadata_file(base_cat_info_fp)
-    with open(base_catalog_info_file, "r") as cat_info_file:
+    with open(base_catalog_info_file, "r", encoding="utf-8") as cat_info_file:
         catalog_info_json = json.load(cat_info_file)
         assert_catalog_info_matches_dict(catalog_info, catalog_info_json)

--- a/tests/hipscat/catalog/dataset/test_dataset.py
+++ b/tests/hipscat/catalog/dataset/test_dataset.py
@@ -25,7 +25,7 @@ def test_read_from_hipscat(dataset_path, base_catalog_info_file, assert_catalog_
     assert dataset.on_disk
     assert dataset.catalog_path == dataset_path
     assert str(dataset.catalog_base_dir) == dataset_path
-    with open(base_catalog_info_file, "r") as cat_info_file:
+    with open(base_catalog_info_file, "r", encoding="utf-8") as cat_info_file:
         catalog_info_json = json.load(cat_info_file)
         assert_catalog_info_matches_dict(dataset.catalog_info, catalog_info_json)
 

--- a/tests/hipscat/catalog/test_catalog.py
+++ b/tests/hipscat/catalog/test_catalog.py
@@ -88,11 +88,7 @@ def test_empty_directory(tmp_path):
 
     ## catalog_info file exists - getting closer
     file_name = os.path.join(catalog_path, "catalog_info.json")
-    with open(
-        file_name,
-        "w",
-        encoding="utf-8",
-    ) as metadata_file:
+    with open(file_name, "w", encoding="utf-8") as metadata_file:
         metadata_file.write('{"catalog_name":"empty", "catalog_type":"source"}')
 
     with pytest.raises(FileNotFoundError):
@@ -100,11 +96,7 @@ def test_empty_directory(tmp_path):
 
     ## partition_info file exists - enough to create a catalog
     file_name = os.path.join(catalog_path, "partition_info.csv")
-    with open(
-        file_name,
-        "w",
-        encoding="utf-8",
-    ) as metadata_file:
+    with open(file_name, "w", encoding="utf-8") as metadata_file:
         metadata_file.write("foo")
 
     catalog = Catalog.read_from_hipscat(catalog_path)

--- a/tests/hipscat/catalog/test_catalog_info.py
+++ b/tests/hipscat/catalog/test_catalog_info.py
@@ -40,6 +40,6 @@ def test_read_from_file(catalog_info_file, assert_catalog_info_matches_dict):
     ]:
         assert column in dataclasses.asdict(catalog_info)
 
-    with open(catalog_info_file, "r") as cat_info_file:
+    with open(catalog_info_file, "r", encoding="utf-8") as cat_info_file:
         catalog_info_json = json.load(cat_info_file)
         assert_catalog_info_matches_dict(catalog_info, catalog_info_json)

--- a/tests/hipscat/inspection/test_almanac.py
+++ b/tests/hipscat/inspection/test_almanac.py
@@ -94,7 +94,6 @@ def test_linked_catalogs_object(default_almanac):
     source_almanac = default_almanac.get_almanac_info(object_almanac.sources[0].catalog_name)
     assert source_almanac.catalog_name == "small_sky_source_catalog"
 
-    ## TODO - this could use some more direct API.
     source_catalog = default_almanac.get_catalog(object_almanac.sources[0].catalog_name)
     assert source_catalog.catalog_name == "small_sky_source_catalog"
 

--- a/tests/hipscat/io/conftest.py
+++ b/tests/hipscat/io/conftest.py
@@ -28,11 +28,7 @@ def assert_text_file_matches():
             file_name (str): fully-specified path of the file to read
         """
         assert os.path.exists(file_name), f"file not found [{file_name}]"
-        with open(
-            file_name,
-            "r",
-            encoding="utf-8",
-        ) as metadata_file:
+        with open(file_name, "r", encoding="utf-8") as metadata_file:
             contents = metadata_file.readlines()
 
         assert len(expected_lines) == len(

--- a/tests/hipscat/io/file_io/test_file_io.py
+++ b/tests/hipscat/io/file_io/test_file_io.py
@@ -93,9 +93,9 @@ def test_load_csv_to_pandas(small_sky_dir):
 
 
 def test_write_df_to_csv(tmp_path):
-    df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)), columns=list("ABCD"))
+    random_df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)), columns=list("ABCD"))
     test_file_path = os.path.join(tmp_path, "test.csv")
     test_file_pointer = get_file_pointer_from_path(test_file_path)
-    write_dataframe_to_csv(df, test_file_pointer, index=False)
+    write_dataframe_to_csv(random_df, test_file_pointer, index=False)
     loaded_df = pd.read_csv(test_file_path)
-    pd.testing.assert_frame_equal(loaded_df, df)
+    pd.testing.assert_frame_equal(loaded_df, random_df)

--- a/tests/hipscat/io/test_write_metadata.py
+++ b/tests/hipscat/io/test_write_metadata.py
@@ -7,9 +7,8 @@ import numpy.testing as npt
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
-import pytest
 
-import hipscat.io.file_io as file_io
+from hipscat.io import file_io
 import hipscat.io.write_metadata as io
 import hipscat.pixel_math as hist
 from hipscat.pixel_math.healpix_pixel import HealpixPixel

--- a/tests/hipscat/pixel_math/test_margin_bounding.py
+++ b/tests/hipscat/pixel_math/test_margin_bounding.py
@@ -68,9 +68,10 @@ def test_get_margin_bounds_and_wcs():
     test_ra3 = 50.61225197
     test_dec3 = 14.4767556
 
-    test_sc = SkyCoord(
-        np.array([test_ra1, test_ra2, test_ra3]), np.array([test_dec1, test_dec2, test_dec3]), unit="deg"
-    )
+    test_ra = np.array([test_ra1, test_ra2, test_ra3])
+    test_dec = np.array([test_dec1, test_dec2, test_dec3])
+
+    test_sc = SkyCoord(test_ra, test_dec, unit="deg")
 
     scale = pm.get_margin_scale(3, 0.1)
     polygon, wcs_margin = pm.get_margin_bounds_and_wcs(3, 4, scale)[0]
@@ -78,9 +79,12 @@ def test_get_margin_bounds_and_wcs():
     assert polygon.area == pytest.approx(756822775.0000424, 0.001)
 
     coord_x, coord_y = wcs_margin.world_to_pixel(test_sc)
-    expected = np.array([False, True, True])
+    expected_pixel_coord = PixCoord(coord_x, coord_y)
+    expected_contains_checks = np.array([False, True, True])
 
-    npt.assert_array_equal(polygon.contains(PixCoord(coord_x, coord_y)), expected)
+    contains_checks = polygon.contains(expected_pixel_coord)
+
+    npt.assert_array_equal(contains_checks, expected_contains_checks)
 
 
 def get_checks_for_bounds(bounds, test_sky_coords):


### PR DESCRIPTION
## Change Description

As mentioned in PR #107 , there are a number of small findings in the tests directory. This cleans them up, by giving longer names, specifying read file encodings, and reducing duplicated code.