### PR TITLE
Require minimum version of typing-extensions.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pyarrow",
     "astropy",
     "regions",
-    "typing-extensions"
+    "typing-extensions>=4.3.0",
 ]
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)
@@ -46,8 +46,6 @@ dev = [
     "ipykernel", # Also used in building notebooks into Sphinx
     "ipython", # Also used in building notebooks into Sphinx
     "myst_parser", # Renders markdown alongside RST
-    "matplotlib", # Used in sample notebook intro_notebook.ipynb
-    "numpy", # Used in sample notebook intro_notebook.ipynb
 ]
 
 [build-system]


### PR DESCRIPTION
Require minimum version of typing-extensions.

Unable to run with versions as old as 3.7. This version number might be aggressive, but I think we'll be ok.