### PR TITLE
Fix mismatched destination pixel map behavior

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pyarrow",
     "astropy",
     "regions",
-    "typing-extensions"
+    "typing-extensions>=4.3.0",
 ]
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)
@@ -46,8 +46,6 @@ dev = [
     "ipykernel", # Also used in building notebooks into Sphinx
     "ipython", # Also used in building notebooks into Sphinx
     "myst_parser", # Renders markdown alongside RST
-    "matplotlib", # Used in sample notebook intro_notebook.ipynb
-    "numpy", # Used in sample notebook intro_notebook.ipynb
 ]
 
 [build-system]

--- a/src/hipscat/pixel_math/partition_stats.py
+++ b/src/hipscat/pixel_math/partition_stats.py
@@ -207,9 +207,9 @@ def compute_pixel_map(histogram, highest_order=10, lowest_order=0, threshold=1_0
         nested_sums.append(histogram.reshape(-1, explosion_factor).sum(axis=1))
     nested_sums.append(histogram)
 
-    ## Determine the highest order that does not exceed the threshold
-    orders_at_threshold = [0 if 0 < k <= threshold else None for k in nested_sums[0]]
-    for order in range(lowest_order, highest_order + 1):
+    ## Determine the lowest order that does not exceed the threshold
+    orders_at_threshold = [lowest_order if 0 < k <= threshold else None for k in nested_sums[lowest_order]]
+    for order in range(lowest_order + 1, highest_order + 1):
         new_orders_at_threshold = np.array(
             [order if 0 < k <= threshold else None for k in nested_sums[order]]
         )

--- a/tests/hipscat/pixel_math/test_partition_stats.py
+++ b/tests/hipscat/pixel_math/test_partition_stats.py
@@ -273,3 +273,29 @@ def test_generate_constant_pixel_map_invalid_inputs():
     ## Order doesn't match histogram length
     with pytest.raises(ValueError, match="histogram is not the right size"):
         hist.generate_constant_pixel_map(initial_histogram, constant_healpix_order=2)
+
+
+def test_destination_map_matching_behavior():
+    """Test that we get the same size destination pixel map, whether we compute
+    directly, or from an existing alignment."""
+    raw_histogram = hist.empty_histogram(2)
+    raw_histogram[0:6] = 22946
+    raw_histogram[64:79] = 185670
+
+    alignment = hist.generate_alignment(
+        raw_histogram,
+        highest_order=2,
+        threshold=1_000_000,
+    )
+    destination_pixel_map_a = hist.compute_pixel_map(
+        raw_histogram,
+        highest_order=2,
+        threshold=1_000_000,
+    )
+
+    destination_pixel_map_b = hist.generate_destination_pixel_map(
+        raw_histogram,
+        alignment,
+    )
+
+    assert len(destination_pixel_map_a) == len(destination_pixel_map_b)


### PR DESCRIPTION
## Change Description

Under some conditions, the destination pixel map produced by `compute_pixel_map` has different destination pixels than that produced by `generate_destination_pixel_map`, using a pre-defined alignment array. In this situation, the alignment and the pixel map will not agree on the correct pixels.

This manifested in the hipscat-import catalog creation splitting inputs according to the alignment, and trying to reduce them according to the destination pixel map, and not finding the appropriate files.

### Bug Fix Checklist
- [x] My fix includes a new test that breaks as a result of the bug (if possible)