### PR TITLE
remove logically unreachable lines to get 100 percent coverage

### DIFF
--- a/src/hipscat/pixel_tree/pixel_node.py
+++ b/src/hipscat/pixel_tree/pixel_node.py
@@ -28,7 +28,6 @@ class PixelNode:
         pixel: HealpixInputTypes,
         node_type: PixelNodeType,
         parent: PixelNode | None,
-        children: List[PixelNode] | None = None,
     ) -> None:
         """Inits PixelNode with its attributes
 
@@ -57,10 +56,6 @@ class PixelNode:
         self.node_type = node_type
         self.parent = parent
         self.children = []
-
-        if children is not None:
-            for child in children:
-                self.add_child_node(child)
 
         if self.parent is not None:
             self.parent.add_child_node(self)

--- a/tests/hipscat/conftest.py
+++ b/tests/hipscat/conftest.py
@@ -14,7 +14,6 @@ def root_pixel_node_data():
         "pixel": HealpixPixel(-1, -1),
         "node_type": PixelNodeType.ROOT,
         "parent": None,
-        "children": None,
     }
 
 
@@ -29,7 +28,6 @@ def inner_pixel_node_data(root_pixel_node):
         "pixel": HealpixPixel(0, 1),
         "node_type": PixelNodeType.INNER,
         "parent": root_pixel_node,
-        "children": None,
     }
 
 
@@ -44,7 +42,6 @@ def leaf_pixel_node_data(inner_pixel_node):
         "pixel": HealpixPixel(1, 12),
         "node_type": PixelNodeType.LEAF,
         "parent": inner_pixel_node,
-        "children": None,
     }
 
 


### PR DESCRIPTION
<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
while waiting on some other PRs, I decided to address something that's been bothering me... the `hipscat` unit tests are off from 100 percent coverage by two lines 😭 however, when I tried writing a test that would cover this, I realized that the lines in question are unreachable, as a child node cannot be created before a parent node, meaning that a user can never pass a list of children nodes into the init of a parent node. I went ahead and removed the code so that we can have full coverage :bowtie: 

## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->

removed unreachable lines.

## Code Quality
- [x] I have read the [Contribution Guide](https://lincc-ppt.readthedocs.io/en/latest/source/contributing.html)
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation