### PR TITLE
Add pixel tree catalog init input type

### DIFF
--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -25,7 +25,7 @@ class Catalog(Dataset):
     """
 
     CatalogInfoClass = CatalogInfo
-    PixelInputTypes = Union[pd.DataFrame, PartitionInfo]
+    PixelInputTypes = Union[pd.DataFrame, PartitionInfo, PixelTree]
     HIPS_CATALOG_TYPES = [CatalogType.OBJECT, CatalogType.SOURCE, CatalogType.MARGIN]
 
     def __init__(
@@ -59,7 +59,18 @@ class Catalog(Dataset):
             return pixels
         if isinstance(pixels, pd.DataFrame):
             return PartitionInfo(pixels)
-        raise TypeError("Pixels must be of type PartitionInfo or Dataframe")
+        if isinstance(pixels, PixelTree):
+            partition_info_dict = {
+                PartitionInfo.METADATA_ORDER_COLUMN_NAME: [],
+                PartitionInfo.METADATA_PIXEL_COLUMN_NAME: [],
+                PartitionInfo.METADATA_DIR_COLUMN_NAME: [],
+            }
+            for node in pixels.root_pixel.get_all_leaf_descendants():
+                partition_info_dict[PartitionInfo.METADATA_ORDER_COLUMN_NAME].append(node.hp_order)
+                partition_info_dict[PartitionInfo.METADATA_PIXEL_COLUMN_NAME].append(node.hp_pixel)
+                partition_info_dict[PartitionInfo.METADATA_DIR_COLUMN_NAME].append(int(node.hp_pixel / 10_000) * 10_000)
+            return PartitionInfo(pd.DataFrame.from_dict(partition_info_dict))
+        raise TypeError("Pixels must be of type PartitionInfo, Dataframe, or PixelTree")
 
     @staticmethod
     def _get_pixel_tree_from_pixels(pixels: PixelInputTypes) -> PixelTree:
@@ -67,7 +78,9 @@ class Catalog(Dataset):
             return PixelTreeBuilder.from_partition_info_df(pixels.data_frame)
         if isinstance(pixels, pd.DataFrame):
             return PixelTreeBuilder.from_partition_info_df(pixels)
-        raise TypeError("Pixels must be of type PartitionInfo or Dataframe")
+        if isinstance(pixels, PixelTree):
+            return pixels
+        raise TypeError("Pixels must be of type PartitionInfo, Dataframe, or PixelTree")
 
     def get_pixels(self):
         """Get all healpix pixels that are contained in the catalog

--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -39,8 +39,8 @@ class Catalog(Dataset):
         Args:
             catalog_info: CatalogInfo object with catalog metadata
             pixels: Specifies the pixels contained in the catalog. Can be either a Dataframe with
-                columns `Norder`, `Dir`, and `Npix` matching a `partition_info.csv` file, or a
-                PartitionInfo object
+                columns `Norder`, `Dir`, and `Npix` matching a `partition_info.csv` file, a
+                `PartitionInfo object`, or a `PixelTree` object
             catalog_path: If the catalog is stored on disk, specify the location of the catalog
                 Does not load the catalog from this path, only store as metadata
         """

--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -68,7 +68,9 @@ class Catalog(Dataset):
             for node in pixels.root_pixel.get_all_leaf_descendants():
                 partition_info_dict[PartitionInfo.METADATA_ORDER_COLUMN_NAME].append(node.hp_order)
                 partition_info_dict[PartitionInfo.METADATA_PIXEL_COLUMN_NAME].append(node.hp_pixel)
-                partition_info_dict[PartitionInfo.METADATA_DIR_COLUMN_NAME].append(int(node.hp_pixel / 10_000) * 10_000)
+                partition_info_dict[PartitionInfo.METADATA_DIR_COLUMN_NAME].append(
+                    int(node.hp_pixel / 10_000) * 10_000
+                )
             return PartitionInfo(pd.DataFrame.from_dict(partition_info_dict))
         raise TypeError("Pixels must be of type PartitionInfo, Dataframe, or PixelTree")
 

--- a/tests/hipscat/catalog/test_catalog.py
+++ b/tests/hipscat/catalog/test_catalog.py
@@ -8,6 +8,7 @@ import pytest
 
 from hipscat.catalog import Catalog, CatalogType, PartitionInfo
 from hipscat.pixel_tree.pixel_node_type import PixelNodeType
+from hipscat.pixel_tree.pixel_tree_builder import PixelTreeBuilder
 
 
 def test_catalog_load(catalog_info, catalog_pixels):
@@ -32,10 +33,24 @@ def test_catalog_wrong_catalog_type(catalog_info, catalog_pixels):
         Catalog(catalog_info, catalog_pixels)
 
 
-def test_different_pixel_input_types(catalog_info, catalog_pixels):
+def test_partition_info_pixel_input_types(catalog_info, catalog_pixels):
     partition_info = PartitionInfo(catalog_pixels)
     catalog = Catalog(catalog_info, partition_info)
     assert len(catalog.get_pixels()) == catalog_pixels.shape[0]
+    assert len(catalog.pixel_tree.root_pixel.get_all_leaf_descendants()) == catalog_pixels.shape[0]
+    for _, pixel in catalog_pixels.iterrows():
+        order = pixel[PartitionInfo.METADATA_ORDER_COLUMN_NAME]
+        pixel = pixel[PartitionInfo.METADATA_PIXEL_COLUMN_NAME]
+        assert (order, pixel) in catalog.pixel_tree
+        assert catalog.pixel_tree[(order, pixel)].node_type == PixelNodeType.LEAF
+
+
+def test_tree_pixel_input(catalog_info, catalog_pixels):
+    partition_info = PartitionInfo(catalog_pixels)
+    tree = PixelTreeBuilder.from_partition_info_df(partition_info.data_frame)
+    catalog = Catalog(catalog_info, tree)
+    assert len(catalog.get_pixels()) == catalog_pixels.shape[0]
+    assert len(catalog.pixel_tree.root_pixel.get_all_leaf_descendants()) == catalog_pixels.shape[0]
     for _, pixel in catalog_pixels.iterrows():
         order = pixel[PartitionInfo.METADATA_ORDER_COLUMN_NAME]
         pixel = pixel[PartitionInfo.METADATA_PIXEL_COLUMN_NAME]


### PR DESCRIPTION
## Change Description

Adds the option to initialize a `Catalog` with a `PixelTree` in addition to the `PartitionInfo` that we currently have.

## Code Quality
- [x] I have read the [Contribution Guide](https://lincc-ppt.readthedocs.io/en/latest/source/contributing.html)
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

### New Feature Checklist
- [x] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [x] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
