### PR TITLE
Add default timeout and trim runtime of overruns.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "src/hipscat/_version.py"
 
+[tool.pytest.ini_options]
+timeout = 1
+
 [tool.coverage.run]
 omit=["src/hipscat/_version.py"]
 

--- a/tests/hipscat/catalog/test_catalog.py
+++ b/tests/hipscat/catalog/test_catalog.py
@@ -108,7 +108,7 @@ def test_cone_filter_big(small_sky_order1_catalog):
     assert (1, 47) in filtered_catalog.pixel_tree
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.timeout(5)
 def test_cone_filter_multiple_order(catalog_info):
     partition_info_df = pd.DataFrame.from_dict(
         {

--- a/tests/hipscat/catalog/test_catalog.py
+++ b/tests/hipscat/catalog/test_catalog.py
@@ -108,6 +108,7 @@ def test_cone_filter_big(small_sky_order1_catalog):
     assert (1, 47) in filtered_catalog.pixel_tree
 
 
+@pytest.mark.timeout(2)
 def test_cone_filter_multiple_order(catalog_info):
     partition_info_df = pd.DataFrame.from_dict(
         {

--- a/tests/hipscat/pixel_math/test_hipscat_id.py
+++ b/tests/hipscat/pixel_math/test_hipscat_id.py
@@ -1,15 +1,15 @@
 """Test construction (and de-construction) of the hipscat ID"""
 
-import numpy as np
 import healpy as hp
+import numpy as np
 import numpy.testing as npt
 import pytest
 
 from hipscat.pixel_math.hipscat_id import (
-    compute_hipscat_id,
-    hipscat_id_to_healpix,
     HIPSCAT_ID_HEALPIX_ORDER,
+    compute_hipscat_id,
     healpix_to_hipscat_id,
+    hipscat_id_to_healpix,
 )
 
 
@@ -71,7 +71,6 @@ def test_list():
     npt.assert_array_equal(result, expected)
 
 
-@pytest.mark.timeout(1)
 def test_load():
     """Generate a kinda big array and make sure the method completes in under a second.
     If this method is failing due to timeouts, please refactor to keep within the time limit.

--- a/tests/hipscat/pixel_math/test_partition_stats.py
+++ b/tests/hipscat/pixel_math/test_partition_stats.py
@@ -205,6 +205,7 @@ def test_compute_pixel_map_order1():
 
     npt.assert_array_equal(result, expected)
 
+@pytest.mark.timeout(2)
 def test_compute_pixel_map_even_sky():
     """Create alignment from an even distribution at order 6"""
     initial_histogram = np.full(hp.order2npix(6), 200)
@@ -213,6 +214,7 @@ def test_compute_pixel_map_even_sky():
     for mapping in result:
         assert mapping.order == 5
 
+@pytest.mark.timeout(2)
 def test_compute_pixel_map_even_sky_enforce_lowest():
     """Create pixel map for an even distribution, and enforce a lowest order bound."""
     initial_histogram = np.full(hp.order2npix(6), 10)

--- a/tests/hipscat/pixel_math/test_partition_stats.py
+++ b/tests/hipscat/pixel_math/test_partition_stats.py
@@ -151,8 +151,9 @@ def test_alignment_small_sky_order2():
     npt.assert_array_equal(result, expected)
 
 
+@pytest.mark.timeout(2)
 def test_alignment_even_sky():
-    """Create alignment from an even distribution at order 8"""
+    """Create alignment from an even distribution at order 7"""
     initial_histogram = np.full(hp.order2npix(7), 40)
     result = hist.generate_alignment(initial_histogram, highest_order=7, threshold=1_000)
     # everything maps to order 5, given the density
@@ -205,6 +206,7 @@ def test_compute_pixel_map_order1():
 
     npt.assert_array_equal(result, expected)
 
+
 @pytest.mark.timeout(2)
 def test_compute_pixel_map_even_sky():
     """Create alignment from an even distribution at order 6"""
@@ -213,6 +215,7 @@ def test_compute_pixel_map_even_sky():
     # everything maps to order 5, given the density
     for mapping in result:
         assert mapping.order == 5
+
 
 @pytest.mark.timeout(2)
 def test_compute_pixel_map_even_sky_enforce_lowest():

--- a/tests/hipscat/pixel_math/test_partition_stats.py
+++ b/tests/hipscat/pixel_math/test_partition_stats.py
@@ -151,7 +151,7 @@ def test_alignment_small_sky_order2():
     npt.assert_array_equal(result, expected)
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.timeout(5)
 def test_alignment_even_sky():
     """Create alignment from an even distribution at order 7"""
     initial_histogram = np.full(hp.order2npix(7), 40)
@@ -207,7 +207,7 @@ def test_compute_pixel_map_order1():
     npt.assert_array_equal(result, expected)
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.timeout(5)
 def test_compute_pixel_map_even_sky():
     """Create alignment from an even distribution at order 6"""
     initial_histogram = np.full(hp.order2npix(6), 200)
@@ -217,7 +217,7 @@ def test_compute_pixel_map_even_sky():
         assert mapping.order == 5
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.timeout(5)
 def test_compute_pixel_map_even_sky_enforce_lowest():
     """Create pixel map for an even distribution, and enforce a lowest order bound."""
     initial_histogram = np.full(hp.order2npix(6), 10)

--- a/tests/hipscat/pixel_math/test_partition_stats.py
+++ b/tests/hipscat/pixel_math/test_partition_stats.py
@@ -153,13 +153,13 @@ def test_alignment_small_sky_order2():
 
 def test_alignment_even_sky():
     """Create alignment from an even distribution at order 8"""
-    initial_histogram = np.full(hp.order2npix(8), 10)
-    result = hist.generate_alignment(initial_histogram, highest_order=8, threshold=1_000)
+    initial_histogram = np.full(hp.order2npix(7), 40)
+    result = hist.generate_alignment(initial_histogram, highest_order=7, threshold=1_000)
     # everything maps to order 5, given the density
     for mapping in result:
         assert mapping[0] == 5
 
-    result = hist.generate_alignment(initial_histogram, highest_order=8, lowest_order=7, threshold=1_000)
+    result = hist.generate_alignment(initial_histogram, highest_order=7, lowest_order=7, threshold=1_000)
     # everything maps to order 7 (would be 5, but lowest of 7 is enforced)
     for mapping in result:
         assert mapping[0] == 7
@@ -205,19 +205,21 @@ def test_compute_pixel_map_order1():
 
     npt.assert_array_equal(result, expected)
 
-
 def test_compute_pixel_map_even_sky():
-    """Create alignment from an even distribution at order 8"""
-    initial_histogram = np.full(hp.order2npix(8), 10)
-    result = hist.compute_pixel_map(initial_histogram, highest_order=8, threshold=1_000)
+    """Create alignment from an even distribution at order 6"""
+    initial_histogram = np.full(hp.order2npix(6), 200)
+    result = hist.compute_pixel_map(initial_histogram, highest_order=6, threshold=1_000)
     # everything maps to order 5, given the density
     for mapping in result:
         assert mapping.order == 5
 
-    result = hist.compute_pixel_map(initial_histogram, highest_order=8, lowest_order=7, threshold=1_000)
-    # everything maps to order 7 (would be 5, but lowest of 7 is enforced)
+def test_compute_pixel_map_even_sky_enforce_lowest():
+    """Create pixel map for an even distribution, and enforce a lowest order bound."""
+    initial_histogram = np.full(hp.order2npix(6), 10)
+    result = hist.compute_pixel_map(initial_histogram, highest_order=6, lowest_order=4, threshold=1_000)
+    # everything maps to order 4 (would be 0, but lowest of 4 is enforced)
     for mapping in result:
-        assert mapping.order == 7
+        assert mapping.order == 4
 
 
 def test_compute_pixel_map_invalid_inputs():


### PR DESCRIPTION
## Change Description

Related to issue #120 

Adds default timeout to the entire test suite (1 second). Trims runtime of the two slowest tests by operating at a lower healpix order. However these tests may still timeout in slower environments, so I've adjusted a few timeouts to 5 seconds so CI can pass. These can be tracked with performance monitoring, when available.