### PR TITLE
Add benchmarking

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,10 +1,12 @@
 # Changes here will be overwritten by Copier
-_commit: v1.3.4
-_src_path: gh:lincc-frameworks/python-project-template
+_commit: v1.4.1-22-g5f17829
+_src_path: ./python-project-template/
 author_email: lincc-frameworks-team@lists.lsst.org
 author_name: LINCC Frameworks
 create_example_module: false
 custom_install: true
+include_benchmarks: true
+include_docs: true
 include_notebooks: true
 mypy_type_checking: none
 package_name: hipscat

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@ If it fixes an open issue, please link to the issue here. If this PR closes an i
 
 
 ## Code Quality
-- [ ] I have read the [Contribution Guide](https://lincc-ppt.readthedocs.io/en/latest/source/contributing.html)
+- [ ] I have read the Contribution Guide
 - [ ] My code follows the code style of this project
 - [ ] My code builds (or compiles) cleanly without any errors or warnings
 - [ ] My code contains relevant comments and necessary documentation
@@ -50,8 +50,8 @@ If it fixes an open issue, please link to the issue here. If this PR closes an i
 - [ ] Any updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
 
 ### Build/CI Change Checklist
-- [ ] If required or optional dependencies have changed (including version numbers), I have updated the [README](https://github.com/lincc-frameworks/python-project-template/blob/main/README.md) to reflect this
-- [ ] If this is a new CI setup, I have added the associated badge to the [README](https://github.com/lincc-frameworks/python-project-template/blob/main/README.md)
+- [ ] If required or optional dependencies have changed (including version numbers), I have updated the README to reflect this
+- [ ] If this is a new CI setup, I have added the associated badge to the README
 
 <!-- ### Version Change Checklist [For Future Use] -->
 

--- a/.github/workflows/asv-main.yml
+++ b/.github/workflows/asv-main.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add results/
+          git add _results/
           git pull
           git commit -m "Upload new benchmarks"
           git push origin main
@@ -90,4 +90,4 @@ jobs:
       - name: Deploy to Github pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: ${{ env.WORKING_DIR }}/html
+          folder: ${{ env.WORKING_DIR }}/_html

--- a/.github/workflows/asv-main.yml
+++ b/.github/workflows/asv-main.yml
@@ -1,0 +1,93 @@
+# This workflow will run benchmarks with airspeed velocity (asv)
+# and publish the results to a dashboard on GH Pages.
+
+name: Run ASV benchmarks for main
+
+on:
+  push:
+    branches: [ main ]
+
+env:
+  PYTHON_VERSION: "3.10"
+  WORKING_DIR: ${{ github.workspace }}/benchmarks
+
+jobs:
+
+  consecutiveness:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set workflows on main to run consecutively
+        uses: mktcode/consecutive-workflow-action@eb43c6b5852dd0e33efa797a1817196d06daa4b2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  setup-python:
+    runs-on: ubuntu-latest
+    needs: consecutiveness
+
+    steps:
+      - name: Cache Python ${{ env.PYTHON_VERSION }}
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: python-${{ env.PYTHON_VERSION }}
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+
+  asv-main:
+    runs-on: ubuntu-latest
+    needs: setup-python
+
+    permissions:
+      contents: write
+
+    defaults:
+      run:
+        working-directory: ${{ env.WORKING_DIR }}
+
+    steps:
+      - name: Checkout main branch of the repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Cache Python ${{ env.PYTHON_VERSION }}
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: python-${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          python -m pip install --upgrade pip
+          pip install asv virtualenv tabulate
+
+      - name: Create ASV machine config file
+        run: asv machine --machine gh-runner --yes
+
+      - name: Run ASV for the main branch
+        run: asv run ALL --skip-existing
+
+      - name: Submit results to the repository
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add results/
+          git pull
+          git commit -m "Upload new benchmarks"
+          git push origin main
+
+      - name: Generate dashboard HTML
+        run: |
+          asv show
+          asv publish
+
+      - name: Deploy to Github pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: ${{ env.WORKING_DIR }}/html

--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -1,0 +1,80 @@
+# This workflow will run daily at 06:45.
+# It will run benchmarks with airspeed velocity (asv)
+# and compare performance with the previous nightly build.
+
+name: Run benchmarks nightly job
+
+on:
+  schedule:
+    - cron: 45 6 * * *
+
+env:
+  PYTHON_VERSION: "3.10"
+  WORKING_DIR: ${{ github.workspace }}/benchmarks
+  NIGHTLY_HASH_FILE: nightly-hash
+
+jobs:
+
+  asv-nightly:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ${{ env.WORKING_DIR }}
+
+    steps:
+      - name: Checkout main branch of the repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Cache Python ${{ env.PYTHON_VERSION }}
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: python-${{ env.PYTHON_VERSION }}
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          python -m pip install --upgrade pip
+          pip install asv virtualenv
+
+      - name: Create ASV machine config file
+        run: asv machine --machine gh-runner --yes
+
+      - name: Get nightly dates under comparison
+        id: nightly-dates
+        run: |
+          echo "yesterday=$(date -d yesterday +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+          echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Use last nightly commit hash from cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.WORKING_DIR }}
+          key: nightly-results-${{ steps.nightly-dates.outputs.yesterday }}
+
+      - name: Run comparison of main against last nightly build
+        run: |
+          HASH_FILE=${{ env.NIGHTLY_HASH_FILE }}
+          CURRENT_HASH=${{ github.sha }}
+
+          if [ -f $HASH_FILE ]; then          
+            PREV_HASH=$(cat $HASH_FILE)
+            asv continuous $PREV_HASH $CURRENT_HASH || true
+            asv compare $PREV_HASH $CURRENT_HASH --sort ratio
+          fi
+
+          echo $CURRENT_HASH > $HASH_FILE
+
+      - name: Update last nightly hash in cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.WORKING_DIR }}
+          key: nightly-results-${{ steps.nightly-dates.outputs.today }}

--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -1,4 +1,4 @@
-# This workflow will run daily at 06:45.
+# This workflow will run daily at 06:45 UTC.
 # It will run benchmarks with airspeed velocity (asv)
 # and compare performance with the previous nightly build.
 

--- a/.github/workflows/asv-pr.yml
+++ b/.github/workflows/asv-pr.yml
@@ -1,0 +1,103 @@
+# This workflow will run benchmarks with airspeed velocity (asv) for pull requests.
+# It will compare the performance of the main branch with the performance of the merge
+# with the new changes and publish a comment with this assessment.  
+
+name: Run ASV benchmarks for PR
+
+on:
+  pull_request:
+    branches: [ main ]
+
+env:
+  PYTHON_VERSION: "3.10"
+  WORKING_DIR: ${{ github.workspace }}/benchmarks
+
+jobs:
+
+  setup-python:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cache Python ${{ env.PYTHON_VERSION }}
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: python-${{ env.PYTHON_VERSION }}
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+
+  asv-pr:
+    runs-on: ubuntu-latest
+    needs: setup-python
+
+    permissions:
+      actions: read
+      pull-requests: write
+
+    defaults:
+      run:
+        working-directory: ${{ env.WORKING_DIR }}
+
+    steps:
+      - name: Checkout PR branch of the repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Cache Python ${{ env.PYTHON_VERSION }}
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: python-${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          python -m pip install --upgrade pip
+          pip install asv virtualenv tabulate lf-asv-formatter
+
+      - name: Get current job logs URL
+        uses: Tiryoh/gha-jobid-action@v0
+        id: jobs
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          job_name: ${{ github.job }}
+
+      - name: Create ASV machine config file
+        run: asv machine --machine gh-runner --yes
+
+      - name: Run comparison of PR against main branch
+        run: |
+          git remote add upstream https://github.com/${{ github.repository }}.git
+          git fetch upstream
+          asv continuous upstream/main HEAD || true
+          asv compare upstream/main HEAD --sort ratio | tee output
+          python -m lf_asv_formatter
+          printf "\n\nClick [here]($STEP_URL) to view all benchmarks." >> output
+        env:
+          STEP_URL: "${{ steps.jobs.outputs.html_url }}#step:8:1"
+
+      - name: Publish comment to PR
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const workingDir = process.env.WORKING_DIR;
+            try {
+              process.chdir(workingDir);
+              const comment = fs.readFileSync('output', 'utf-8');
+              const { data } = await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body: comment,
+              });
+              console.log('Comment published:', data.html_url);
+            } catch (err) {
+              console.error(err);
+            }

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -24,9 +24,8 @@ jobs:
       run: |
         sudo apt-get update
         python -m pip install --upgrade pip
+        if [ -f docs/requirements.txt ]; then pip install -r docs/requirements.txt; fi
         pip install .
-        pip install .[dev]
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Install notebook requirements
       run: |
         sudo apt-get install pandoc

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,5 +1,7 @@
 # This workflow will run daily at 06:45.
 # It will install Python dependencies and run tests with a variety of Python versions.
+# See documentation for help debugging smoke test issues:
+#    https://lincc-ppt.readthedocs.io/en/latest/practices/ci_testing.html#version-culprit
 
 name: Unit test smoke test
 

--- a/.gitignore
+++ b/.gitignore
@@ -139,4 +139,9 @@ dask-worker-space/
 # tmp directory
 tmp/
 
-**/.DS_Store
+# Mac OS
+.DS_Store
+
+# Airspeed Velocity performance results
+_results/
+_html/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     # This hook should always pass. It will print a message if the local version 
     # is out of date.
   - repo: https://github.com/lincc-frameworks/pre-commit-hooks
-    rev: v0.1
+    rev: v0.1.1
     hooks:
       - id: check-lincc-frameworks-template-version
         name: Check template version

--- a/.prepare_project.sh
+++ b/.prepare_project.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+echo "Initializing local git repository"
+{
+    gitversion=( $(git version | sed 's/^.* //;s/\./ /g') )
+    if let "${gitversion[0]}<2"; then
+	# manipulate directly
+	git init . && echo 'ref: refs/heads/main' >.git/HEAD
+    elif let "${gitversion[0]}==2 & ${gitversion[1]}<34"; then
+	# rename master to main
+	git init . && { git branch -m master main 2>/dev/null || true; };
+    else
+	# set the initial branch name to main
+	git init --initial-branch=main >/dev/null
+    fi
+} > /dev/null
+
+echo "Installing package and runtime dependencies in local environment"
+pip install -e . > /dev/null
+
+echo "Installing developer dependencies in local environment"
+pip install -e .'[dev]' > /dev/null
+
+echo "Installing pre-commit"
+pre-commit install > /dev/null

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -1,0 +1,77 @@
+{
+    // The version of the config file format. Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+    // The name of the project being benchmarked.
+    "project": "hipscat",
+    // The project's homepage.
+    "project_url": "https://github.com/astronomy-commons/hipscat",
+    // The URL or local path of the source code repository for the
+    // project being benchmarked.
+    "repo": "..",
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "tip" (for mercurial).
+    "branches": [
+        "HEAD"
+    ],
+    "build_command": [
+        "python -m build --wheel -o {build_cache_dir} {build_dir}"
+    ],
+    // The DVCS being used. If not set, it will be automatically
+    // determined from "repo" by looking at the protocol in the URL
+    // (if remote), or by looking for special directories, such as
+    // ".git" (if local).
+    "dvcs": "git",
+    // The tool to use to create environments. May be "conda",
+    // "virtualenv" or other value depending on the plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "virtualenv",
+    // the base URL to show a commit for the project.
+    "show_commit_url": "https://github.com/astronomy-commons/hipscat/commit/",
+    // The Pythons you'd like to test against. If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    "pythons": [
+        "3.10"
+    ],
+    // The matrix of dependencies to test. Each key is the name of a
+    // package (in PyPI) and the values are version numbers.  An empty
+    // list indicates to just test against the default (latest)
+    // version.
+    "matrix": {
+        "Cython": [],
+        "build": [],
+        "packaging": []
+    },
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in. If not provided, defaults to "benchmarks".
+    "benchmark_dir": ".",
+    // The directory (relative to the current directory) to cache the Python
+    // environments in. If not provided, defaults to "env".
+    "env_dir": "env",
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in. If not provided, defaults to "results".
+    "results_dir": "_results",
+    // The directory (relative to the current directory) that the html tree
+    // should be written to. If not provided, defaults to "html".
+    "html_dir": "_html",
+    // The number of characters to retain in the commit hashes.
+    // "hash_length": 8,
+    // `asv` will cache wheels of the recent builds in each
+    // environment, making them faster to install next time. This is
+    // number of builds to keep, per environment.
+    "build_cache_size": 8
+    // The commits after which the regression search in `asv publish`
+    // should start looking for regressions. Dictionary whose keys are
+    // regexps matching to benchmark names, and values corresponding to
+    // the commit (exclusive) after which to start looking for
+    // regressions. The default is to start from the first commit
+    // with results. If the commit is `null`, regression detection is
+    // skipped for the matching benchmark.
+    //
+    // "regressions_first_commits": {
+    //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
+    //    "another_benchmark": null,   // Skip regression detection altogether
+    // }
+}

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,0 +1,45 @@
+"""Two sample benchmarks to compute runtime and memory usage.
+
+For more information on writing benchmarks:
+https://asv.readthedocs.io/en/stable/writing_benchmarks.html."""
+
+import healpy as hp
+import numpy as np
+import pandas as pd
+
+import hipscat.pixel_math as hist
+from hipscat.catalog import Catalog, PartitionInfo
+from hipscat.catalog.catalog_info import CatalogInfo
+
+def time_test_alignment_even_sky():
+    """Create alignment from an even distribution at order 7"""
+    initial_histogram = np.full(hp.order2npix(7), 40)
+    result = hist.generate_alignment(initial_histogram, highest_order=7, threshold=1_000)
+    # everything maps to order 5, given the density
+    for mapping in result:
+        assert mapping[0] == 5
+
+
+def time_test_cone_filter_multiple_order():
+    """Create a catalog cone filter where we have multiple orders in the catalog"""
+    catalog_info = CatalogInfo(
+        **{
+            "catalog_name": "test_name",
+            "catalog_type": "object",
+            "total_rows": 10,
+            "epoch": "J2000",
+            "ra_column": "ra",
+            "dec_column": "dec",
+        }
+    )
+    partition_info_df = pd.DataFrame.from_dict(
+        {
+            PartitionInfo.METADATA_ORDER_COLUMN_NAME: [6, 7, 7],
+            PartitionInfo.METADATA_PIXEL_COLUMN_NAME: [30, 124, 5000],
+        }
+    )
+    catalog = Catalog(catalog_info, partition_info_df)
+    filtered_catalog = catalog.filter_by_cone(47.1, 6, 30)
+    assert len(filtered_catalog.partition_info.data_frame) == 2
+    assert (6, 30) in filtered_catalog.pixel_tree
+    assert (7, 124) in filtered_catalog.pixel_tree

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==6.1.3
-sphinx_rtd_theme==1.2.0
+sphinx-rtd-theme==1.2.0
 sphinx-autoapi==2.0.1
 nbsphinx
 ipykernel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
     "pyarrow",
     "astropy",
     "typing-extensions>=4.3.0",
-    "numba"
+    "numba",
+    "ipykernel", # Support for Jupyter notebooks
 ]
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)
@@ -36,7 +37,7 @@ dev = [
     "pytest-cov", # Used to report total code coverage
     "pytest-timeout", # Used to test for code efficiency
     "sphinx==6.1.3", # Used to automatically generate documentation
-    "sphinx_rtd_theme==1.2.0", # Used to render documentation
+    "sphinx-rtd-theme==1.2.0", # Used to render documentation
     "sphinx-autoapi==2.0.1", # Used to automatically generate api documentation
     # if you add dependencies here while experimenting in a notebook and you
     # want that notebook to render in your documentation, please add the
@@ -50,7 +51,7 @@ dev = [
 
 [build-system]
 requires = [
-    "setuptools>=45", # Used to build and package the Python project
+    "setuptools>=62", # Used to build and package the Python project
     "setuptools_scm>=6.2", # Gets release version from git. Makes it available programmatically
 ]
 build-backend = "setuptools.build_meta"
@@ -60,6 +61,9 @@ write_to = "src/hipscat/_version.py"
 
 [tool.pytest.ini_options]
 timeout = 1
+testpaths = [
+    "tests",
+]
 
 [tool.coverage.run]
 omit=["src/hipscat/_version.py"]


### PR DESCRIPTION
## Change Description

Adds support for ASV benchmarking:

- updated our copier to latest version
- includes asv workflows to be run on merges, PRs, and nightly 
- adds two initial benchmarks, based on unit tests that have a `timeout` annotation

NB: this was the first use of our ASV templates, so there may still be some rough edges. 