### PR TITLE
Add pixel input to ease catalog creation in tests.

### DIFF
--- a/src/hipscat/catalog/partition_info.py
+++ b/src/hipscat/catalog/partition_info.py
@@ -58,3 +58,25 @@ class PartitionInfo:
 
         data_frame = file_io.load_csv_to_pandas(partition_info_file)
         return cls(data_frame)
+
+    @classmethod
+    def from_healpix(cls, healpix_pixels: List[HealpixPixel]):
+        """Create a partition info object from a list of constituent healpix pixels.
+
+        Args:
+            healpix_pixels: list of healpix pixels
+        Returns:
+            A `PartitionInfo` object with the same healpix pixels
+        """
+        partition_info_dict = {
+            PartitionInfo.METADATA_ORDER_COLUMN_NAME: [],
+            PartitionInfo.METADATA_PIXEL_COLUMN_NAME: [],
+            PartitionInfo.METADATA_DIR_COLUMN_NAME: [],
+        }
+        for pixel in healpix_pixels:
+            partition_info_dict[PartitionInfo.METADATA_ORDER_COLUMN_NAME].append(pixel.order)
+            partition_info_dict[PartitionInfo.METADATA_PIXEL_COLUMN_NAME].append(pixel.pixel)
+            partition_info_dict[PartitionInfo.METADATA_DIR_COLUMN_NAME].append(
+                int(pixel.pixel / 10_000) * 10_000
+            )
+        return cls(pd.DataFrame.from_dict(partition_info_dict))

--- a/src/hipscat/pixel_tree/pixel_tree_builder.py
+++ b/src/hipscat/pixel_tree/pixel_tree_builder.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import List
+
 import pandas as pd
 
 from hipscat.catalog.partition_info import PartitionInfo
@@ -47,6 +49,21 @@ class PixelTreeBuilder:
         builder = PixelTreeBuilder()
         # pylint: disable=protected-access
         builder._create_tree_from_partition_info_df(partition_info_df)
+        return builder.build()
+
+    @staticmethod
+    def from_healpix(healpix_pixels: List[HealpixPixel]) -> PixelTree:
+        """Build a tree from a list of constituent healpix pixels
+
+        Args:
+            healpix_pixels: list of healpix pixels
+
+        Returns:
+            The pixel tree with the leaf pixels specified in the list
+        """
+        builder = PixelTreeBuilder()
+        for pixel in healpix_pixels:
+            builder.create_node_and_parent_if_not_exist((pixel.order, pixel.pixel), PixelNodeType.LEAF)
         return builder.build()
 
     def contains(self, pixel: HealpixInputTypes) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import dataclasses
 import os
 import os.path
+from typing import List
 
 import pandas as pd
 import pytest
@@ -11,6 +12,7 @@ from hipscat.catalog.association_catalog.partition_join_info import PartitionJoi
 from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.catalog.dataset.base_catalog_info import BaseCatalogInfo
 from hipscat.inspection.almanac import Almanac
+from hipscat.pixel_math import HealpixPixel
 
 DATA_DIR_NAME = "data"
 ALMANAC_DIR_NAME = "almanac"
@@ -187,7 +189,7 @@ def catalog_info(catalog_info_data) -> CatalogInfo:
 
 
 @pytest.fixture
-def catalog_pixels() -> pd.DataFrame:
+def catalog_pixels_df() -> pd.DataFrame:
     return pd.DataFrame.from_dict(
         {
             PartitionInfo.METADATA_ORDER_COLUMN_NAME: [1, 1, 2],
@@ -195,6 +197,11 @@ def catalog_pixels() -> pd.DataFrame:
             PartitionInfo.METADATA_PIXEL_COLUMN_NAME: [0, 1, 8],
         }
     )
+
+
+@pytest.fixture
+def catalog_pixels() -> List[HealpixPixel]:
+    return [HealpixPixel(1, 0), HealpixPixel(1, 1), HealpixPixel(2, 8)]
 
 
 @pytest.fixture


### PR DESCRIPTION
## Change Description

Add list of `HealpixPixel`s to the allowed input types when creating a new catalog.

In https://github.com/astronomy-commons/hipscat-import/pull/108, I needed to create a simple catalog using particular pixels in a unit test. It requires knowledge of the structure of the partition info dataframe, and needless pandas boilerplate.

```
    catalog_pixels = pd.DataFrame(
        data=[[1, 0, 16], [2, 0, 68], [2, 0, 69], [2, 0, 70], [2, 0, 71]],
        columns=["Norder", "Dir", "Npix"],
    )
    object_catalog = Catalog(CatalogInfo(**catalog_info_data), catalog_pixels)
    catalog_pixels = pd.DataFrame(
        data=[[1, 0, 16]],
        columns=["Norder", "Dir", "Npix"],
    )
    source_catalog = Catalog(CatalogInfo(**source_catalog_info), catalog_pixels)
```

would be simplified to the more readable (or something like it):

```
    object_catalog = Catalog(CatalogInfo(**catalog_info_data), 
          [(1, 16), (2, 6), (2, 6), (2, 70), (2, 71)])
    source_catalog = Catalog(CatalogInfo(**source_catalog_info), [(1, 16)])
```

## Code Quality
- [x] I have read the [Contribution Guide](https://lincc-ppt.readthedocs.io/en/latest/source/contributing.html)
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation