### PR TITLE
Fix paths ala PPT PR #258

### DIFF
--- a/.github/workflows/asv-main.yml
+++ b/.github/workflows/asv-main.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add _results/
+          git add _results/ -f
           git pull
           git commit -m "Upload new benchmarks"
           git push origin main


### PR DESCRIPTION
## Change Description

Override the `.gitignore` and allow pushing the benchmarking results to the benchmarking branch during the workflow.

Addresses failure of workflow: https://github.com/astronomy-commons/hipscat/actions/runs/5833805090