### PR TITLE
Sean/fix catalog info types

### DIFF
--- a/src/hipscat/catalog/association_catalog/association_catalog.py
+++ b/src/hipscat/catalog/association_catalog/association_catalog.py
@@ -20,6 +20,8 @@ class AssociationCatalog(Dataset):
     """
 
     CatalogInfoClass = AssociationCatalogInfo
+    catalog_info: AssociationCatalogInfo
+
     JoinPixelInputTypes = Union[list, pd.DataFrame, PartitionJoinInfo]
 
     def __init__(

--- a/src/hipscat/catalog/association_catalog/association_catalog.py
+++ b/src/hipscat/catalog/association_catalog/association_catalog.py
@@ -21,7 +21,7 @@ class AssociationCatalog(Dataset):
     """
 
     CatalogInfoClass: TypeAlias = AssociationCatalogInfo
-    catalog_info: AssociationCatalogInfo
+    catalog_info: CatalogInfoClass
 
     JoinPixelInputTypes = Union[list, pd.DataFrame, PartitionJoinInfo]
 

--- a/src/hipscat/catalog/association_catalog/association_catalog.py
+++ b/src/hipscat/catalog/association_catalog/association_catalog.py
@@ -1,6 +1,7 @@
 from typing import Tuple, Union
 
 import pandas as pd
+from typing_extensions import TypeAlias
 
 from hipscat.catalog.association_catalog.association_catalog_info import AssociationCatalogInfo
 from hipscat.catalog.association_catalog.partition_join_info import PartitionJoinInfo
@@ -19,7 +20,7 @@ class AssociationCatalog(Dataset):
     Catalog, corresponding to each pair of partitions in each catalog that contain rows to join.
     """
 
-    CatalogInfoClass = AssociationCatalogInfo
+    CatalogInfoClass: TypeAlias = AssociationCatalogInfo
     catalog_info: AssociationCatalogInfo
 
     JoinPixelInputTypes = Union[list, pd.DataFrame, PartitionJoinInfo]

--- a/src/hipscat/catalog/association_catalog/association_catalog.py
+++ b/src/hipscat/catalog/association_catalog/association_catalog.py
@@ -20,6 +20,8 @@ class AssociationCatalog(Dataset):
     Catalog, corresponding to each pair of partitions in each catalog that contain rows to join.
     """
 
+    # Update CatalogInfoClass, used to check if the catalog_info is the correct type, and
+    # set the catalog info to the correct type
     CatalogInfoClass: TypeAlias = AssociationCatalogInfo
     catalog_info: CatalogInfoClass
 

--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -29,6 +29,8 @@ class Catalog(Dataset):
     PixelInputTypes = Union[pd.DataFrame, PartitionInfo, PixelTree, List[HealpixPixel]]
     HIPS_CATALOG_TYPES = [CatalogType.OBJECT, CatalogType.SOURCE, CatalogType.MARGIN]
 
+    # Update CatalogInfoClass, used to check if the catalog_info is the correct type, and
+    # set the catalog info to the correct type
     CatalogInfoClass: TypeAlias = CatalogInfo
     catalog_info: CatalogInfoClass
 

--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -25,9 +25,11 @@ class Catalog(Dataset):
     `Norder=/Dir=/Npix=.parquet`
     """
 
-    CatalogInfoClass = CatalogInfo
     PixelInputTypes = Union[pd.DataFrame, PartitionInfo, PixelTree, List[HealpixPixel]]
     HIPS_CATALOG_TYPES = [CatalogType.OBJECT, CatalogType.SOURCE, CatalogType.MARGIN]
+
+    CatalogInfoClass = CatalogInfo
+    catalog_info: CatalogInfo
 
     def __init__(
         self,

--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -30,7 +30,7 @@ class Catalog(Dataset):
     HIPS_CATALOG_TYPES = [CatalogType.OBJECT, CatalogType.SOURCE, CatalogType.MARGIN]
 
     CatalogInfoClass: TypeAlias = CatalogInfo
-    catalog_info: CatalogInfo
+    catalog_info: CatalogInfoClass
 
     def __init__(
         self,

--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -5,6 +5,7 @@ import dataclasses
 from typing import List, Tuple, Union
 
 import pandas as pd
+from typing_extensions import TypeAlias
 
 from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.catalog.catalog_type import CatalogType
@@ -28,7 +29,7 @@ class Catalog(Dataset):
     PixelInputTypes = Union[pd.DataFrame, PartitionInfo, PixelTree, List[HealpixPixel]]
     HIPS_CATALOG_TYPES = [CatalogType.OBJECT, CatalogType.SOURCE, CatalogType.MARGIN]
 
-    CatalogInfoClass = CatalogInfo
+    CatalogInfoClass: TypeAlias = CatalogInfo
     catalog_info: CatalogInfo
 
     def __init__(

--- a/src/hipscat/catalog/dataset/dataset.py
+++ b/src/hipscat/catalog/dataset/dataset.py
@@ -1,6 +1,6 @@
-from typing import Tuple, Type
+from typing import Tuple
 
-from typing_extensions import Self
+from typing_extensions import Self, TypeAlias
 
 from hipscat.catalog.dataset.base_catalog_info import BaseCatalogInfo
 from hipscat.io import FilePointer, file_io, paths
@@ -15,7 +15,7 @@ class Dataset:
     some catalog info or catalog directory
     """
 
-    CatalogInfoClass: Type[BaseCatalogInfo] = BaseCatalogInfo
+    CatalogInfoClass: TypeAlias = BaseCatalogInfo
 
     def __init__(
         self,


### PR DESCRIPTION
## Change Description

Updates the Catalog and AssociationCatalog definitions to make sure the `catalog_info` property is typed properly. The type of the class's `catalog_info` property should match the catalog type. Updating an init  The method of setting this before, by using a type variable that was overwritten, did not work.


## Solution Description
The type variable has been changed to a Type Alias, which allows the constructor to be typed properly, and in the Dataset subclasses the type of the catalog_info property is explicitly set to overwrite the type.

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
