### PR TITLE
Add string repr of node. Parametrize tests.

### DIFF
--- a/src/hipscat/pixel_tree/pixel_node.py
+++ b/src/hipscat/pixel_tree/pixel_node.py
@@ -60,6 +60,12 @@ class PixelNode:
         if self.parent is not None:
             self.parent.add_child_node(self)
 
+    def __str__(self) -> str:
+        return f"{self.node_type} Order: {self.pixel.order}, Pixel: {self.pixel.pixel}"
+
+    def __repr__(self):
+        return self.__str__()
+
     @property
     def hp_order(self):
         """The order of the HealpixPixel the node is at"""

--- a/tests/hipscat/pixel_math/test_healpix_pixel.py
+++ b/tests/hipscat/pixel_math/test_healpix_pixel.py
@@ -41,21 +41,23 @@ def test_pixel_str_and_repr():
     assert repr(pix) == test_string
 
 
-def test_convert_lower_order():
-    test_cases = [
+@pytest.mark.parametrize(
+    "order, pixel, final_order, final_pixel",
+    [
         (3, 10, 2, 2),
         (6, 1033, 5, 258),
         (4, 0, 3, 0),
         (5, 400, 2, 6),
         (2, 4, 0, 0),
         (3, 10, 3, 10),
-    ]
-    for order, pixel, final_order, final_pixel in test_cases:
-        delta = order - final_order
-        pixel = HealpixPixel(order, pixel)
-        final_pix = pixel.convert_to_lower_order(delta)
-        assert final_pix.order == final_order
-        assert final_pix.pixel == final_pixel
+    ],
+)
+def test_convert_lower_order(order, pixel, final_order, final_pixel):
+    delta = order - final_order
+    pixel = HealpixPixel(order, pixel)
+    final_pix = pixel.convert_to_lower_order(delta)
+    assert final_pix.order == final_order
+    assert final_pix.pixel == final_pixel
 
 
 def test_convert_lower_order_fails_below_zero():
@@ -74,13 +76,14 @@ def test_convert_lower_order_fails_negative():
         pixel.convert_to_lower_order(-1)
 
 
-def test_convert_higher_order():
-    test_cases = [(3, 10, 1), (6, 1033, 3), (4, 0, 1), (5, 400, 2), (2, 4, 0), (0, 10, 2)]
-    for order, pixel, delta_order in test_cases:
-        converted_pixels = HealpixPixel(order, pixel).convert_to_higher_order(delta_order)
-        final_order = order + delta_order
-        for final_pixel in range(pixel * 4**delta_order, (pixel + 1) * 4**delta_order):
-            assert HealpixPixel(final_order, final_pixel) in converted_pixels
+@pytest.mark.parametrize(
+    "order, pixel, delta_order", [(3, 10, 1), (6, 1033, 3), (4, 0, 1), (5, 400, 2), (2, 4, 0), (0, 10, 2)]
+)
+def test_convert_higher_order(order, pixel, delta_order):
+    converted_pixels = HealpixPixel(order, pixel).convert_to_higher_order(delta_order)
+    final_order = order + delta_order
+    for final_pixel in range(pixel * 4**delta_order, (pixel + 1) * 4**delta_order):
+        assert HealpixPixel(final_order, final_pixel) in converted_pixels
 
 
 def test_convert_higher_order_fails_above_limit():

--- a/tests/hipscat/pixel_tree/test_pixel_node.py
+++ b/tests/hipscat/pixel_tree/test_pixel_node.py
@@ -160,3 +160,13 @@ def test_remove_child_link_wrong_node_errors(root_pixel_node, leaf_pixel_node):
     assert leaf_pixel_node not in root_pixel_node.children
     with pytest.raises(ValueError):
         leaf_pixel_node.remove_child_link(leaf_pixel_node)
+
+
+def test_node_string(root_pixel_node, leaf_pixel_node):
+    root_string = "PixelNodeType.ROOT Order: -1, Pixel: -1"
+    assert str(root_pixel_node) == root_string
+    assert repr(root_pixel_node) == root_string
+
+    leaf_string = "PixelNodeType.LEAF Order: 1, Pixel: 12"
+    assert str(leaf_pixel_node) == leaf_string
+    assert repr(leaf_pixel_node) == leaf_string


### PR DESCRIPTION
## Change Description

Adding a debug string for pixel tree node - helpful when prototyping pixel tree manipulation.

Also noticed some tests that could be parametrized (while I was copy/pasting nearby ones).

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [ ] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation