### PR TITLE
Add method to get filepointer's basename

### DIFF
--- a/src/hipscat/io/file_io/__init__.py
+++ b/src/hipscat/io/file_io/__init__.py
@@ -17,6 +17,7 @@ from .file_pointer import (
     directory_has_contents,
     does_file_or_directory_exist,
     find_files_matching_path,
+    get_basename_from_filepointer,
     get_directory_contents,
     get_file_pointer_from_path,
     is_regular_file,

--- a/src/hipscat/io/file_io/file_io.py
+++ b/src/hipscat/io/file_io/file_io.py
@@ -78,6 +78,7 @@ def load_csv_to_pandas(file_pointer: FilePointer, **kwargs) -> pd.DataFrame:
     """
     return pd.read_csv(file_pointer, **kwargs)
 
+
 def load_parquet_to_pandas(file_pointer: FilePointer, **kwargs) -> pd.DataFrame:
     """Load a parquet file to a pandas dataframe
 

--- a/src/hipscat/io/file_io/file_pointer.py
+++ b/src/hipscat/io/file_io/file_pointer.py
@@ -11,6 +11,18 @@ def get_file_pointer_from_path(path: str) -> FilePointer:
     return FilePointer(path)
 
 
+def get_basename_from_filepointer(pointer: FilePointer) -> str:
+    """Returns the base name of a regular file. May return empty string if the file is a directory.
+
+    Args:
+        pointer: `FilePointer` object to find a basename within
+
+    Returns:
+        string representation of the basename of a file.
+    """
+    return os.path.basename(pointer)
+
+
 def append_paths_to_pointer(pointer: FilePointer, *paths: str) -> FilePointer:
     """Append directories and/or a file name to a specified file pointer.
 

--- a/tests/hipscat/io/file_io/test_file_io.py
+++ b/tests/hipscat/io/file_io/test_file_io.py
@@ -93,6 +93,7 @@ def test_load_csv_to_pandas(small_sky_dir):
     loaded_df = load_csv_to_pandas(partition_info_pointer)
     pd.testing.assert_frame_equal(csv_df, loaded_df)
 
+
 def test_load_parquet_to_pandas(small_sky_dir):
     pixel_data_path = pixel_catalog_file(small_sky_dir, 0, 11)
     parquet_df = pd.read_parquet(pixel_data_path)

--- a/tests/hipscat/io/file_io/test_file_pointers.py
+++ b/tests/hipscat/io/file_io/test_file_pointers.py
@@ -5,6 +5,7 @@ from hipscat.io.file_io import (
     directory_has_contents,
     does_file_or_directory_exist,
     find_files_matching_path,
+    get_basename_from_filepointer,
     get_directory_contents,
     get_file_pointer_from_path,
     is_regular_file,
@@ -14,6 +15,12 @@ from hipscat.io.file_io import (
 def test_get_pointer_from_path(tmp_path):
     tmp_pointer = get_file_pointer_from_path(str(tmp_path))
     assert str(tmp_pointer) == str(tmp_path)
+
+
+def test_get_basename_from_filepointer(tmp_path):
+    catalog_info_string = os.path.join(tmp_path, "catalog_info.json")
+    catalog_info_pointer = get_file_pointer_from_path(catalog_info_string)
+    assert get_basename_from_filepointer(catalog_info_pointer) == "catalog_info.json"
 
 
 def test_file_or_dir_exist(small_sky_dir):


### PR DESCRIPTION
## Change Description

Add a method to get the basename of a filepointer object. e.g. find `catalog_info.json` from `/path/to/catalogs/ps1/catalog_info.json`

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation