### PR TITLE
create generate_negative_tree_pixels

### DIFF
--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import dataclasses
 from typing import List, Tuple, Union
 
+import healpy as hp
+import numpy as np
 import pandas as pd
 from typing_extensions import TypeAlias
 
@@ -14,6 +16,7 @@ from hipscat.catalog.partition_info import PartitionInfo
 from hipscat.io import FilePointer, file_io, paths
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.cone_filter import filter_pixels_by_cone
+from hipscat.pixel_tree.pixel_node_type import PixelNodeType
 from hipscat.pixel_tree.pixel_tree import PixelTree
 from hipscat.pixel_tree.pixel_tree_builder import PixelTreeBuilder
 
@@ -141,3 +144,51 @@ class Catalog(Dataset):
             total_rows=None,
         )
         return Catalog(filtered_catalog_info, filtered_cone_pixels)
+
+    # pylint: disable=too-many-locals
+    def generate_negative_tree_pixels(self) -> List[HealpixPixel]:
+        """Get the leaf nodes at each healpix order that have zero catalog data.
+
+        For example, if an example catalog only had data points in pixel 0 at
+        order 0, then this method would return order 0's pixels 1 through 11.
+        Used for getting full coverage on margin caches.
+
+        Returns:
+            List of HealpixPixels representing the 'negative tree' for the catalog.
+        """
+        max_depth = self.partition_info.get_highest_order()
+        missing_pixels = []
+        pixels_at_order = self.pixel_tree.root_pixel.children
+
+        covered_orders = []
+        for order_i in range(0, max_depth + 1):
+            npix = hp.nside2npix(2**order_i)
+            covered_orders.append(np.zeros(npix))
+
+        for order in range(0, max_depth + 1):
+            next_order_children = []
+            leaf_pixels = []
+
+            for node in pixels_at_order:
+                pixel = node.pixel.pixel
+                covered_orders[order][pixel] = 1
+                if node.node_type == PixelNodeType.LEAF:
+                    leaf_pixels.append(pixel)
+                else:
+                    for child in node.children:
+                        next_order_children.append(child)
+
+            zero_leafs = np.argwhere(covered_orders[order] == 0).flatten()
+            for pix in zero_leafs:
+                missing_pixels.append(HealpixPixel(order, pix))
+                leaf_pixels.append(pix)
+
+            pixels_at_order = next_order_children
+
+            for order_j in range(order + 1, max_depth + 1):
+                explosion_factor = 4 ** (order_j - order)
+                for pixel in leaf_pixels:
+                    covered_pix = range(pixel * explosion_factor, (pixel + 1) * explosion_factor)
+                    covered_orders[order_j][covered_pix] = 1
+
+        return missing_pixels

--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -175,8 +175,7 @@ class Catalog(Dataset):
                 if node.node_type == PixelNodeType.LEAF:
                     leaf_pixels.append(pixel)
                 else:
-                    for child in node.children:
-                        next_order_children.append(child)
+                    next_order_children.extend(node.children)
 
             zero_leafs = np.argwhere(covered_orders[order] == 0).flatten()
             for pix in zero_leafs:

--- a/src/hipscat/pixel_math/healpix_pixel.py
+++ b/src/hipscat/pixel_math/healpix_pixel.py
@@ -32,11 +32,6 @@ class HealpixPixel:
     def __repr__(self):
         return self.__str__()
 
-    def __eq__(self, __value: object) -> bool:
-        if not isinstance(__value, HealpixPixel):
-            return False
-        return self.order == __value.order and self.pixel == __value.pixel
-
     def convert_to_lower_order(self, delta_order: int) -> HealpixPixel:
         """Returns the HEALPix pixel that contains the pixel at a lower order
 

--- a/src/hipscat/pixel_math/healpix_pixel.py
+++ b/src/hipscat/pixel_math/healpix_pixel.py
@@ -32,6 +32,11 @@ class HealpixPixel:
     def __repr__(self):
         return self.__str__()
 
+    def __eq__(self, __value: object) -> bool:
+        if not isinstance(__value, HealpixPixel):
+            return False
+        return self.order == __value.order and self.pixel == __value.pixel
+
     def convert_to_lower_order(self, delta_order: int) -> HealpixPixel:
         """Returns the HEALPix pixel that contains the pixel at a lower order
 

--- a/tests/hipscat/catalog/test_catalog.py
+++ b/tests/hipscat/catalog/test_catalog.py
@@ -7,9 +7,9 @@ import pandas.testing
 import pytest
 
 from hipscat.catalog import Catalog, CatalogType, PartitionInfo
+from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_tree.pixel_node_type import PixelNodeType
 from hipscat.pixel_tree.pixel_tree_builder import PixelTreeBuilder
-from hipscat.pixel_math import HealpixPixel
 
 
 def test_catalog_load(catalog_info, catalog_pixels_df, catalog_pixels):
@@ -170,3 +170,70 @@ def test_empty_directory(tmp_path):
 
     catalog = Catalog.read_from_hipscat(catalog_path)
     assert catalog.catalog_name == "empty"
+
+def test_generate_negative_tree_pixels(small_sky_order1_catalog):
+    """Test generate_negative_tree_pixels on a basic catalog."""
+    expected_pixels = [
+        HealpixPixel(0,0),
+        HealpixPixel(0,1),
+        HealpixPixel(0,2),
+        HealpixPixel(0,3),
+        HealpixPixel(0,4),
+        HealpixPixel(0,5),
+        HealpixPixel(0,6),
+        HealpixPixel(0,7),
+        HealpixPixel(0,8),
+        HealpixPixel(0,9),
+        HealpixPixel(0,10),
+    ]
+
+    negative_tree = small_sky_order1_catalog.generate_negative_tree_pixels()
+
+    assert negative_tree == expected_pixels
+
+def test_generate_negative_tree_pixels_order_0(small_sky_catalog):
+    """Test generate_negative_tree_pixels on a catalog with only order 0 pixels."""
+    expected_pixels = [
+        HealpixPixel(0,0),
+        HealpixPixel(0,1),
+        HealpixPixel(0,2),
+        HealpixPixel(0,3),
+        HealpixPixel(0,4),
+        HealpixPixel(0,5),
+        HealpixPixel(0,6),
+        HealpixPixel(0,7),
+        HealpixPixel(0,8),
+        HealpixPixel(0,9),
+        HealpixPixel(0,10),
+    ]
+
+    negative_tree = small_sky_catalog.generate_negative_tree_pixels()
+
+    assert negative_tree == expected_pixels
+
+def test_generate_negative_tree_pixels_multi_order(small_sky_order1_catalog):
+    """Test generate_negative_tree_pixels on a catalog with
+        missing pixels on multiple order.
+    """
+    # remove one of the order 1 pixels from the catalog.
+    nodes = small_sky_order1_catalog.pixel_tree.root_pixel.children[0].children
+    small_sky_order1_catalog.pixel_tree.root_pixel.children[0].children = nodes[1:]
+
+    expected_pixels = [
+        HealpixPixel(0,0),
+        HealpixPixel(0,1),
+        HealpixPixel(0,2),
+        HealpixPixel(0,3),
+        HealpixPixel(0,4),
+        HealpixPixel(0,5),
+        HealpixPixel(0,6),
+        HealpixPixel(0,7),
+        HealpixPixel(0,8),
+        HealpixPixel(0,9),
+        HealpixPixel(0,10),
+        HealpixPixel(1,44),
+    ]
+
+    negative_tree = small_sky_order1_catalog.generate_negative_tree_pixels()
+
+    assert negative_tree == expected_pixels


### PR DESCRIPTION
<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
resolves #134 
- Creates a new `Catalog` method `generate_negative_tree_pixels` to get a list of pixels that represent leaf nodes with zero data in them.
- Also adds an `__eq__` dunder method to `HealpixPixel` to make elementwise comparison between pixels easier!
- Adds unit tests for new functionality

- [x] My PR includes a link to the issue that I am addressing



## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->
I took @delucchi-cmu 's example [version](https://github.com/delucchi-cmu/hipscripts/blob/main/twiddling/negative_tree.ipynb), made some tweaks to that algorithm to make it work for Order 0 pixels, then made it iterative to make the code safer.

(one small thing I should note is that the iterative version is significantly slower than the recursive version, by a factor of 10. However, in either case the method is still fast and isn't going to be a bottleneck for any computational problems, so I went with the slower + safer version.)

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### New Feature Checklist
- [x] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [x] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### Documentation Change Checklist
- [x] Any updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
