### PR TITLE
Require pyarrow>=10.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "healpy",
     "pandas",
     "setuptools_scm",
-    "pyarrow",
+    "pyarrow>=10.0.0",
     "astropy",
     "typing-extensions>=4.3.0",
     "numba",


### PR DESCRIPTION
## Change Description

The `filesystem` argument was only added to various pyarrow methods in v10.0.0.

https://issues.apache.org/jira/browse/ARROW-16719