### PR TITLE
Address pylint issues under /tests/

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -30,7 +30,7 @@ jobs:
         pip install .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Analyze code with linter
-
       run: |
         pylint -rn -sn --recursive=y ./src --rcfile=./src/.pylintrc
+        pylint -rn -sn --recursive=y ./tests --rcfile=./tests/.pylintrc
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import dataclasses
-import os
 import os.path
 from typing import List
 

--- a/tests/hipscat/catalog/test_catalog.py
+++ b/tests/hipscat/catalog/test_catalog.py
@@ -171,67 +171,70 @@ def test_empty_directory(tmp_path):
     catalog = Catalog.read_from_hipscat(catalog_path)
     assert catalog.catalog_name == "empty"
 
+
 def test_generate_negative_tree_pixels(small_sky_order1_catalog):
     """Test generate_negative_tree_pixels on a basic catalog."""
     expected_pixels = [
-        HealpixPixel(0,0),
-        HealpixPixel(0,1),
-        HealpixPixel(0,2),
-        HealpixPixel(0,3),
-        HealpixPixel(0,4),
-        HealpixPixel(0,5),
-        HealpixPixel(0,6),
-        HealpixPixel(0,7),
-        HealpixPixel(0,8),
-        HealpixPixel(0,9),
-        HealpixPixel(0,10),
+        HealpixPixel(0, 0),
+        HealpixPixel(0, 1),
+        HealpixPixel(0, 2),
+        HealpixPixel(0, 3),
+        HealpixPixel(0, 4),
+        HealpixPixel(0, 5),
+        HealpixPixel(0, 6),
+        HealpixPixel(0, 7),
+        HealpixPixel(0, 8),
+        HealpixPixel(0, 9),
+        HealpixPixel(0, 10),
     ]
 
     negative_tree = small_sky_order1_catalog.generate_negative_tree_pixels()
 
     assert negative_tree == expected_pixels
 
+
 def test_generate_negative_tree_pixels_order_0(small_sky_catalog):
     """Test generate_negative_tree_pixels on a catalog with only order 0 pixels."""
     expected_pixels = [
-        HealpixPixel(0,0),
-        HealpixPixel(0,1),
-        HealpixPixel(0,2),
-        HealpixPixel(0,3),
-        HealpixPixel(0,4),
-        HealpixPixel(0,5),
-        HealpixPixel(0,6),
-        HealpixPixel(0,7),
-        HealpixPixel(0,8),
-        HealpixPixel(0,9),
-        HealpixPixel(0,10),
+        HealpixPixel(0, 0),
+        HealpixPixel(0, 1),
+        HealpixPixel(0, 2),
+        HealpixPixel(0, 3),
+        HealpixPixel(0, 4),
+        HealpixPixel(0, 5),
+        HealpixPixel(0, 6),
+        HealpixPixel(0, 7),
+        HealpixPixel(0, 8),
+        HealpixPixel(0, 9),
+        HealpixPixel(0, 10),
     ]
 
     negative_tree = small_sky_catalog.generate_negative_tree_pixels()
 
     assert negative_tree == expected_pixels
 
+
 def test_generate_negative_tree_pixels_multi_order(small_sky_order1_catalog):
     """Test generate_negative_tree_pixels on a catalog with
-        missing pixels on multiple order.
+    missing pixels on multiple order.
     """
     # remove one of the order 1 pixels from the catalog.
     nodes = small_sky_order1_catalog.pixel_tree.root_pixel.children[0].children
     small_sky_order1_catalog.pixel_tree.root_pixel.children[0].children = nodes[1:]
 
     expected_pixels = [
-        HealpixPixel(0,0),
-        HealpixPixel(0,1),
-        HealpixPixel(0,2),
-        HealpixPixel(0,3),
-        HealpixPixel(0,4),
-        HealpixPixel(0,5),
-        HealpixPixel(0,6),
-        HealpixPixel(0,7),
-        HealpixPixel(0,8),
-        HealpixPixel(0,9),
-        HealpixPixel(0,10),
-        HealpixPixel(1,44),
+        HealpixPixel(0, 0),
+        HealpixPixel(0, 1),
+        HealpixPixel(0, 2),
+        HealpixPixel(0, 3),
+        HealpixPixel(0, 4),
+        HealpixPixel(0, 5),
+        HealpixPixel(0, 6),
+        HealpixPixel(0, 7),
+        HealpixPixel(0, 8),
+        HealpixPixel(0, 9),
+        HealpixPixel(0, 10),
+        HealpixPixel(1, 44),
     ]
 
     negative_tree = small_sky_order1_catalog.generate_negative_tree_pixels()

--- a/tests/hipscat/conftest.py
+++ b/tests/hipscat/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 
 from hipscat.catalog import Catalog
 from hipscat.pixel_math import HealpixPixel

--- a/tests/hipscat/io/conftest.py
+++ b/tests/hipscat/io/conftest.py
@@ -1,25 +1,19 @@
 """Set of convenience methods for testing file contents"""
 
-import os
 import re
 
 import pyarrow as pa
 import pytest
 
-from hipscat.io.file_io.file_pointer import (
-    FilePointer,
-    get_fs,
-    does_file_or_directory_exist
-)
-from hipscat.io.file_io.file_io import (
-    load_text_file
-)
+from hipscat.io.file_io.file_io import load_text_file
+from hipscat.io.file_io.file_pointer import does_file_or_directory_exist
+
 # pylint: disable=missing-function-docstring, redefined-outer-name
 
 
 @pytest.fixture
 def assert_text_file_matches():
-    def assert_text_file_matches(expected_lines, file_name, storage_options: dict={}):
+    def assert_text_file_matches(expected_lines, file_name, storage_options: dict = None):
         """Convenience method to read a text file and compare the contents, line for line.
 
         When file contents get even a little bit big, it can be difficult to see
@@ -36,7 +30,9 @@ def assert_text_file_matches():
             file_name (str): fully-specified path of the file to read
             storage_options (dict): dictionary of filesystem storage options
         """
-        assert does_file_or_directory_exist(file_name, storage_options=storage_options), f"file not found [{file_name}]"
+        assert does_file_or_directory_exist(
+            file_name, storage_options=storage_options
+        ), f"file not found [{file_name}]"
         contents = load_text_file(file_name, storage_options=storage_options)
 
         assert len(expected_lines) == len(

--- a/tests/hipscat/io/file_io/test_file_io.py
+++ b/tests/hipscat/io/file_io/test_file_io.py
@@ -1,26 +1,23 @@
 import json
 import os
 
-import numpy as np 
+import numpy as np
 import pandas as pd
 import pytest
 
 from hipscat.io.file_io import (
+    delete_file,
     get_file_pointer_from_path,
     load_csv_to_pandas,
     load_json_file,
     load_parquet_to_pandas,
     make_directory,
+    read_parquet_file_to_pandas,
     remove_directory,
     write_dataframe_to_csv,
     write_string_to_file,
-    delete_file,
-    read_parquet_file_to_pandas
 )
-from hipscat.io.file_io.file_pointer import (
-    does_file_or_directory_exist,
-
-)
+from hipscat.io.file_io.file_pointer import does_file_or_directory_exist
 from hipscat.io.paths import pixel_catalog_file
 
 

--- a/tests/hipscat/io/file_io/test_file_pointers.py
+++ b/tests/hipscat/io/file_io/test_file_pointers.py
@@ -1,5 +1,5 @@
 import os
-import fsspec
+
 import pytest
 
 from hipscat.io.file_io import (
@@ -9,15 +9,12 @@ from hipscat.io.file_io import (
     find_files_matching_path,
     get_basename_from_filepointer,
     get_directory_contents,
+    get_file_pointer_for_fs,
     get_file_pointer_from_path,
     is_regular_file,
-    get_file_pointer_for_fs,
-    strip_leading_slash_for_pyarrow
+    strip_leading_slash_for_pyarrow,
 )
-
-from hipscat.io.file_io.file_pointer import (
-    get_fs
-)
+from hipscat.io.file_io.file_pointer import get_fs
 
 
 def test_get_pointer_from_path(tmp_path):
@@ -84,7 +81,7 @@ def test_directory_has_contents(small_sky_order1_dir, tmp_path):
 def test_get_directory_contents(small_sky_order1_dir, tmp_path):
     small_sky_contents = get_directory_contents(small_sky_order1_dir)
 
-    for i,content in enumerate(small_sky_contents):
+    for i, content in enumerate(small_sky_contents):
         if not content.startswith("/"):
             small_sky_contents[i] = f"/{content}"
 
@@ -101,20 +98,25 @@ def test_get_directory_contents(small_sky_order1_dir, tmp_path):
 
     assert len(get_directory_contents(tmp_path)) == 0
 
+
 def test_get_fs():
     filesystem, _ = get_fs("file://")
     assert filesystem.protocol == "file"
-    
-    #this will fail if the environment installs lakefs to import
+
+    # this will fail if the environment installs lakefs to import
     with pytest.raises(ImportError):
         get_fs("lakefs://")
 
     with pytest.raises(ValueError):
         get_fs("invalid://")
 
+
 def test_get_file_pointer_for_fs():
     test_abfs_protocol_path = get_file_pointer_from_path("abfs:///container/path/to/parquet/file")
-    assert get_file_pointer_for_fs("abfs", file_pointer=test_abfs_protocol_path) == "/container/path/to/parquet/file"
+    assert (
+        get_file_pointer_for_fs("abfs", file_pointer=test_abfs_protocol_path)
+        == "/container/path/to/parquet/file"
+    )
     test_s3_protocol_path = get_file_pointer_from_path("s3:///bucket/path/to/catalog.json")
     assert get_file_pointer_for_fs("s3", file_pointer=test_s3_protocol_path) == "/bucket/path/to/catalog.json"
     test_local_path = get_file_pointer_from_path("/path/to/file")
@@ -125,6 +127,12 @@ def test_get_file_pointer_for_fs():
 
 def test_strip_leading_slash_for_pyarrow():
     test_leading_slash_filename = get_file_pointer_from_path("/bucket/path/test.txt")
-    assert strip_leading_slash_for_pyarrow(test_leading_slash_filename, protocol="abfs") == "bucket/path/test.txt"
+    assert (
+        strip_leading_slash_for_pyarrow(test_leading_slash_filename, protocol="abfs")
+        == "bucket/path/test.txt"
+    )
     test_non_leading_slash_filenaem = get_file_pointer_from_path("bucket/path/test.txt")
-    assert strip_leading_slash_for_pyarrow(test_non_leading_slash_filenaem, protocol="abfs") == "bucket/path/test.txt"
+    assert (
+        strip_leading_slash_for_pyarrow(test_non_leading_slash_filenaem, protocol="abfs")
+        == "bucket/path/test.txt"
+    )

--- a/tests/hipscat/io/test_write_metadata.py
+++ b/tests/hipscat/io/test_write_metadata.py
@@ -6,11 +6,10 @@ import shutil
 import numpy.testing as npt
 import pandas as pd
 import pyarrow as pa
-import pyarrow.parquet as pq
 
-from hipscat.io import file_io
 import hipscat.io.write_metadata as io
 import hipscat.pixel_math as hist
+from hipscat.io import file_io
 from hipscat.pixel_math.healpix_pixel import HealpixPixel
 
 
@@ -237,7 +236,7 @@ def check_parquet_schema(file_name, expected_schema, expected_num_row_groups=1):
 
     assert schema.equals(expected_schema, check_metadata=False)
 
-    parquet_file =  file_io.read_parquet_file(file_name)
+    parquet_file = file_io.read_parquet_file(file_name)
     assert parquet_file.metadata.num_row_groups == expected_num_row_groups
 
     for row_index in range(0, parquet_file.metadata.num_row_groups):

--- a/tests/hipscat/pixel_math/test_hipscat_id.py
+++ b/tests/hipscat/pixel_math/test_hipscat_id.py
@@ -119,9 +119,7 @@ def test_hipscat_id_to_healpix():
 def test_healpix_to_hipscat_id_single():
     orders = [3, 3, 4, 1]
     pixels = [0, 12, 1231, 11]
-    pixels_at_high_order = [
-        p * (4 ** (HIPSCAT_ID_HEALPIX_ORDER - o)) for o, p in zip(orders, pixels)
-    ]
+    pixels_at_high_order = [p * (4 ** (HIPSCAT_ID_HEALPIX_ORDER - o)) for o, p in zip(orders, pixels)]
     lon, lat = hp.pix2ang(
         [2**HIPSCAT_ID_HEALPIX_ORDER] * len(orders), pixels_at_high_order, nest=True, lonlat=True
     )
@@ -133,9 +131,7 @@ def test_healpix_to_hipscat_id_single():
 def test_healpix_to_hipscat_id_array():
     orders = [3, 3, 4, 1]
     pixels = [0, 12, 1231, 11]
-    pixels_at_high_order = [
-        p * (4 ** (HIPSCAT_ID_HEALPIX_ORDER - o)) for o, p in zip(orders, pixels)
-    ]
+    pixels_at_high_order = [p * (4 ** (HIPSCAT_ID_HEALPIX_ORDER - o)) for o, p in zip(orders, pixels)]
     lon, lat = hp.pix2ang(
         [2**HIPSCAT_ID_HEALPIX_ORDER] * len(orders), pixels_at_high_order, nest=True, lonlat=True
     )
@@ -148,9 +144,7 @@ def test_healpix_to_hipscat_id_offset():
     orders = [3, 3, 4, 1]
     pixels = [0, 0, 1231, 11]
     offsets = [0, 1, 0, 0]
-    pixels_at_high_order = [
-        p * (4 ** (HIPSCAT_ID_HEALPIX_ORDER - o)) for o, p in zip(orders, pixels)
-    ]
+    pixels_at_high_order = [p * (4 ** (HIPSCAT_ID_HEALPIX_ORDER - o)) for o, p in zip(orders, pixels)]
     lon, lat = hp.pix2ang(
         [2**HIPSCAT_ID_HEALPIX_ORDER] * len(orders), pixels_at_high_order, nest=True, lonlat=True
     )

--- a/tests/hipscat/pixel_math/test_margin_bounding.py
+++ b/tests/hipscat/pixel_math/test_margin_bounding.py
@@ -11,7 +11,7 @@ def test_check_margin_bounds():
     """Make sure check_margin_bounds works properly"""
 
     ras = np.array([42.4704538, 56.25, 56.25, 50.61225197])
-    decs = np.array([1.4593925, 9.6, 10., 14.4767556])
+    decs = np.array([1.4593925, 9.6, 10.0, 14.4767556])
 
     checks = pm.check_margin_bounds(ras, decs, 3, 4, 360.0)
 
@@ -23,27 +23,31 @@ def test_check_margin_bounds():
 def test_check_margin_bounds_low_order():
     """Make sure check_margin_bounds works when using a low order healpixel"""
 
-    ras = np.array([
-        142.4704538,
-        45.09,
-        45.2,
-        37.31343956517391,
-        42.649354753311535,
-        32.62796809350278,
-        39.89468227954832,
-        27.718121934039974
-    ])
+    ras = np.array(
+        [
+            142.4704538,
+            45.09,
+            45.2,
+            37.31343956517391,
+            42.649354753311535,
+            32.62796809350278,
+            39.89468227954832,
+            27.718121934039974,
+        ]
+    )
 
-    decs = np.array([
-        1.4593925,
-        0.0,
-        0.0,
-        6.566326903165274,
-        2.005185097251452,
-        10.597884275167646,
-        4.465967883812584,
-        14.959672304191956
-    ])
+    decs = np.array(
+        [
+            1.4593925,
+            0.0,
+            0.0,
+            6.566326903165274,
+            2.005185097251452,
+            10.597884275167646,
+            4.465967883812584,
+            14.959672304191956,
+        ]
+    )
 
     checks = pm.check_margin_bounds(ras, decs, 0, 4, 360.0)
 
@@ -81,14 +85,16 @@ def test_check_polar_margin_bounds_south():
 
     npt.assert_array_equal(vals, expected)
 
+
 def test_check_margin_bounds_uneven():
     """Ensure check_margin_bounds fails when ra and dec arrays are unbalanced."""
 
     ras = np.array([42.4704538, 56.25, 56.25, 50.61225197])
-    decs = np.array([1.4593925, 9.6, 10.])
+    decs = np.array([1.4593925, 9.6, 10.0])
 
     with pytest.raises(ValueError, match="length of r_asc"):
         pm.check_margin_bounds(ras, decs, 3, 4, 360.0)
+
 
 def test_check_margin_bounds_empty():
     """Ensure check_margin_bounds works when passed empty coordinate arrays."""

--- a/tests/hipscat/pixel_tree/test_pixel_tree_builder.py
+++ b/tests/hipscat/pixel_tree/test_pixel_tree_builder.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import pytest
 
-from hipscat.catalog import PartitionInfo
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_tree.pixel_node import PixelNode
 from hipscat.pixel_tree.pixel_node_type import PixelNodeType


### PR DESCRIPTION
## Change Description

The recent PR to update the copier version runs pre-commit as a CI action. This includes a pylint check against the /tests/ directory, which was missing previously. This PR updates /tests/ files to get them in pylint compliance.

See https://github.com/astronomy-commons/hipscat/pull/143

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation