### PR TITLE
Create hipscat index column constant

### DIFF
--- a/src/hipscat/pixel_math/hipscat_id.py
+++ b/src/hipscat/pixel_math/hipscat_id.py
@@ -19,6 +19,7 @@ See the README in this directory for more information on the fiddly pixel math.
 import healpy as hp
 import numpy as np
 
+HIPSCAT_ID_COLUMN = "_hipscat_index"
 HIPSCAT_ID_HEALPIX_ORDER = 19
 
 


### PR DESCRIPTION
Creates a constant for the HiPSCat index column (_hipscat_index). Relates to issue [#38](https://github.com/astronomy-commons/lsdb/issues/38).

- [X] My PR includes a link to the issue that I am addressing

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation