### PR TITLE
Add argument to truncate hipscat_index to order

### DIFF
--- a/src/hipscat/pixel_math/hipscat_id.py
+++ b/src/hipscat/pixel_math/hipscat_id.py
@@ -66,16 +66,16 @@ def _compute_hipscat_id_from_mapped_pixels(mapped_pixels, offset_counter):
     return shifted_pixels
 
 
-def hipscat_id_to_healpix(ids):
-    """Convert some hipscat ids to the healpix pixel at order 19.
+def hipscat_id_to_healpix(ids, target_order = HIPSCAT_ID_HEALPIX_ORDER):
+    """Convert some hipscat ids to the healpix pixel at the specified order
     This is just bit-shifting the counter away.
 
     Args:
         ids (list[int64]): list of well-formatted hipscat ids
     Returns:
-        list of order 19 pixels from the hipscat id
+        list of target_order pixels from the hipscat id
     """
-    return np.asarray(ids, dtype=np.uint64) >> (64 - (4 + 2 * HIPSCAT_ID_HEALPIX_ORDER))
+    return np.asarray(ids, dtype=np.uint64) >> (64 - (4 + 2 * target_order))
 
 
 def healpix_to_hipscat_id(order: int, pixel: int, counter: int = 0) -> int:

--- a/tests/hipscat/pixel_math/test_hipscat_id.py
+++ b/tests/hipscat/pixel_math/test_hipscat_id.py
@@ -116,6 +116,26 @@ def test_hipscat_id_to_healpix():
     npt.assert_array_equal(result, expected)
 
 
+def test_hipscat_id_to_healpix_low_order():
+    """Test the inverse operation"""
+    ids = [
+        5482513871577022464,
+        5482513871577022465,
+        5482513871577022466,
+        5476738131329810432,  # out of sequence
+        5482513871577022467,
+        5482513871577022468,
+        5482513871577022469,
+        5476738131329810433,  # out of sequence
+        5482513871577022470,
+    ]
+
+    result = hipscat_id_to_healpix(ids, target_order=4)
+
+    expected = [1217, 1217, 1217, 1216, 1217, 1217, 1217, 1216, 1217]
+
+    npt.assert_array_equal(result, expected)
+
 def test_healpix_to_hipscat_id_single():
     orders = [3, 3, 4, 1]
     pixels = [0, 12, 1231, 11]


### PR DESCRIPTION
## Change Description

This is related to implementation of https://github.com/astronomy-commons/hipscat-import/issues/46

Given an existing hipscat_index, use it as the mapping spatial information at a target order.