### PR TITLE
Don't require full catalog to plot pixel list

### DIFF
--- a/src/hipscat/inspection/__init__.py
+++ b/src/hipscat/inspection/__init__.py
@@ -1,1 +1,1 @@
-from .visualize_catalog import plot_pixels, plot_points
+from .visualize_catalog import plot_pixel_list, plot_pixels, plot_points

--- a/src/hipscat/inspection/visualize_catalog.py
+++ b/src/hipscat/inspection/visualize_catalog.py
@@ -70,10 +70,11 @@ def plot_pixels(catalog: Catalog, projection="moll", draw_map=True):
 
 
 def plot_pixel_list(pixels: List[HealpixPixel], plot_title: str = "", projection="moll", draw_map=True):
-    """Create a visual map of the pixel density of the catalog.
+    """Create a visual map of the pixel density of a list of pixels.
 
     Args:
-        catalog (`hipscat.catalog.Catalog`) Catalog to display
+        pixels: healpix pixels (order and pixel number) to visualize
+        plot_title (str): heading for the plot
         projection (str) The map projection to use. Valid values include:
             - moll - Molleweide projection (default)
             - gnom - Gnomonic projection

--- a/src/hipscat/inspection/visualize_catalog.py
+++ b/src/hipscat/inspection/visualize_catalog.py
@@ -3,7 +3,7 @@
 NB: Testing validity of generated plots is currently not tested in our unit test suite.
 """
 
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Union
 
 import healpy as hp
 import numpy as np
@@ -11,6 +11,7 @@ from matplotlib import pyplot as plt
 
 from hipscat.catalog import Catalog
 from hipscat.io import file_io, paths
+from hipscat.pixel_math import HealpixPixel
 
 
 def _read_point_map(catalog_base_dir, storage_options: Union[Dict[Any, Any], None] = None):
@@ -27,7 +28,7 @@ def _read_point_map(catalog_base_dir, storage_options: Union[Dict[Any, Any], Non
 
 
 def plot_points(catalog: Catalog, projection="moll", draw_map=True):
-    """Create a visual map of the input points of the catalog.
+    """Create a visual map of the input points of an in-memory catalog.
 
     Args:
         catalog (`hipscat.catalog.Catalog`) Catalog to display
@@ -37,6 +38,8 @@ def plot_points(catalog: Catalog, projection="moll", draw_map=True):
             - cart - Cartesian projection
             - orth - Orthographic projection
     """
+    if not catalog.on_disk:
+        raise ValueError("on disk catalog required for point-wise visualization")
     point_map = _read_point_map(catalog.catalog_base_dir, storage_options=catalog.storage_options)
     _plot_healpix_map(
         point_map,
@@ -58,7 +61,26 @@ def plot_pixels(catalog: Catalog, projection="moll", draw_map=True):
             - orth - Orthographic projection
     """
     pixels = catalog.get_healpix_pixels()
-    max_order = catalog.partition_info.get_highest_order()
+    plot_pixel_list(
+        pixels=pixels,
+        plot_title=f"Catalog pixel density map - {catalog.catalog_name}",
+        projection=projection,
+        draw_map=draw_map,
+    )
+
+
+def plot_pixel_list(pixels: List[HealpixPixel], plot_title: str = "", projection="moll", draw_map=True):
+    """Create a visual map of the pixel density of the catalog.
+
+    Args:
+        catalog (`hipscat.catalog.Catalog`) Catalog to display
+        projection (str) The map projection to use. Valid values include:
+            - moll - Molleweide projection (default)
+            - gnom - Gnomonic projection
+            - cart - Cartesian projection
+            - orth - Orthographic projection
+    """
+    max_order = np.max(pixels).order
 
     order_map = np.full(hp.order2npix(max_order), hp.pixelfunc.UNSEEN)
 
@@ -74,7 +96,7 @@ def plot_pixels(catalog: Catalog, projection="moll", draw_map=True):
     _plot_healpix_map(
         order_map,
         projection,
-        f"Catalog pixel density map - {catalog.catalog_name}",
+        plot_title,
         draw_map=draw_map,
     )
 

--- a/tests/hipscat/inspection/test_visualize_catalog.py
+++ b/tests/hipscat/inspection/test_visualize_catalog.py
@@ -1,7 +1,7 @@
 import pytest
 
 from hipscat.catalog import Catalog
-from hipscat.inspection import plot_pixels, plot_points
+from hipscat.inspection import plot_pixel_list, plot_pixels, plot_points
 
 
 @pytest.mark.parametrize("projection", ["moll", "gnom", "cart", "orth"])
@@ -33,3 +33,12 @@ def test_generate_map_order1(small_sky_order1_dir):
     cat = Catalog.read_from_hipscat(small_sky_order1_dir)
     plot_pixels(cat, draw_map=False)
     plot_points(cat, draw_map=False)
+
+
+def test_visualize_in_memory_catalogs(catalog_info, catalog_pixels):
+    catalog = Catalog(catalog_info, catalog_pixels)
+    plot_pixels(catalog, draw_map=False)
+    plot_pixel_list(catalog_pixels, plot_title="My special catalog", draw_map=False)
+
+    with pytest.raises(ValueError, match="on disk catalog required"):
+        plot_points(catalog, draw_map=False)

--- a/tests/hipscat/inspection/test_visualize_catalog.py
+++ b/tests/hipscat/inspection/test_visualize_catalog.py
@@ -36,6 +36,7 @@ def test_generate_map_order1(small_sky_order1_dir):
 
 
 def test_visualize_in_memory_catalogs(catalog_info, catalog_pixels):
+    """Test behavior of visualization methods for non-on-disk catalogs and pixel data."""
     catalog = Catalog(catalog_info, catalog_pixels)
     plot_pixels(catalog, draw_map=False)
     plot_pixel_list(catalog_pixels, plot_title="My special catalog", draw_map=False)


### PR DESCRIPTION
## Change Description

Closes #157 and partially addresses #156.

## Solution Description

Give an explicit error when attempting to visualize a non-on-disk catalog, since no fits points file will be present. Support showing the pixel map for a list of HealpixPixel, outside of a constructed catalog.

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation