### PR TITLE
Join info from parquet metadata

### DIFF
--- a/src/hipscat/catalog/association_catalog/association_catalog.py
+++ b/src/hipscat/catalog/association_catalog/association_catalog.py
@@ -62,21 +62,27 @@ class AssociationCatalog(HealpixDataset):
         cls, catalog_base_dir: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
     ) -> Tuple[CatalogInfoClass, PixelInputTypes, JoinPixelInputTypes]:  # type: ignore[override]
         args = super()._read_args(catalog_base_dir, storage_options=storage_options)
-        partition_join_info_file = paths.get_partition_join_info_pointer(catalog_base_dir)
-        partition_join_info = PartitionJoinInfo.read_from_file(
-            partition_join_info_file, storage_options=storage_options
-        )
+        metadata_file = paths.get_parquet_metadata_pointer(catalog_base_dir)
+        if file_io.does_file_or_directory_exist(metadata_file, storage_options=storage_options):
+            partition_join_info = PartitionJoinInfo.read_from_file(
+                metadata_file, storage_options=storage_options
+            )
+        else:
+            partition_join_info_file = paths.get_partition_join_info_pointer(catalog_base_dir)
+            partition_join_info = PartitionJoinInfo.read_from_csv(
+                partition_join_info_file, storage_options=storage_options
+            )
         return args + (partition_join_info,)
 
     @classmethod
-    def _check_files_exist(
-        cls, catalog_base_dir: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
-    ):
+    def _check_files_exist(cls, catalog_base_dir: FilePointer, storage_options: dict = None):
         super()._check_files_exist(catalog_base_dir, storage_options=storage_options)
         partition_join_info_file = paths.get_partition_join_info_pointer(catalog_base_dir)
-        if not file_io.does_file_or_directory_exist(
-            partition_join_info_file, storage_options=storage_options
+        metadata_file = paths.get_parquet_metadata_pointer(catalog_base_dir)
+        if not (
+            file_io.does_file_or_directory_exist(partition_join_info_file, storage_options=storage_options)
+            or file_io.does_file_or_directory_exist(metadata_file, storage_options=storage_options)
         ):
             raise FileNotFoundError(
-                f"No partition join info found where expected: {str(partition_join_info_file)}"
+                f"_metadata or partition join info file is required in catalog directory {catalog_base_dir}"
             )

--- a/src/hipscat/catalog/association_catalog/partition_join_info.py
+++ b/src/hipscat/catalog/association_catalog/partition_join_info.py
@@ -44,6 +44,9 @@ class PartitionJoinInfo:
 
         Lots of cute comprehension is happening here, so watch out!
         We create tuple of (primary order/pixel) and [array of tuples of (join order/pixel)]
+
+        Returns:
+            dictionary mapping (primary order/pixel) to [array of (join order/pixel)]
         """
         primary_map = self.data_frame.groupby(
             [self.PRIMARY_ORDER_COLUMN_NAME, self.PRIMARY_PIXEL_COLUMN_NAME], group_keys=True
@@ -88,12 +91,14 @@ class PartitionJoinInfo:
         write_parquet_metadata_for_batches(batches, catalog_path, storage_options)
 
     @classmethod
-    def read_from_file(cls, metadata_file: FilePointer, storage_options: Union[Dict[Any, Any], None] = None):
+    def read_from_file(
+        cls, metadata_file: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
+    ) -> Self:
         """Read partition join info from a `_metadata` file to create an object
 
         Args:
-            metadata_file: FilePointer to the `_metadata` file
-            storage_options: dictionary that contains abstract filesystem credentials
+            metadata_file (FilePointer): FilePointer to the `_metadata` file
+            storage_options (dict): dictionary that contains abstract filesystem credentials
 
         Returns:
             A `PartitionJoinInfo` object with the data from the file
@@ -120,8 +125,8 @@ class PartitionJoinInfo:
         """Read partition join info from a `partition_join_info.csv` file to create an object
 
         Args:
-            partition_join_info_file: FilePointer to the `partition_join_info.csv` file
-            storage_options: dictionary that contains abstract filesystem credentials
+            partition_join_info_file (FilePointer): FilePointer to the `partition_join_info.csv` file
+            storage_options (dict): dictionary that contains abstract filesystem credentials
 
         Returns:
             A `PartitionJoinInfo` object with the data from the file

--- a/src/hipscat/catalog/association_catalog/partition_join_info.py
+++ b/src/hipscat/catalog/association_catalog/partition_join_info.py
@@ -1,9 +1,18 @@
-from typing import Any, Dict, Union
+"""Container class to hold primary-to-join partition metadata"""
+
+from typing import Any, Dict, List, Union
 
 import pandas as pd
+import pyarrow as pa
 from typing_extensions import Self
 
 from hipscat.io import FilePointer, file_io
+from hipscat.io.parquet_metadata import (
+    read_row_group_fragments,
+    row_group_stat_single_value,
+    write_parquet_metadata_for_batches,
+)
+from hipscat.pixel_math.healpix_pixel import HealpixPixel
 
 
 class PartitionJoinInfo:
@@ -15,7 +24,7 @@ class PartitionJoinInfo:
     JOIN_PIXEL_COLUMN_NAME = "join_Npix"
 
     COLUMN_NAMES = [
-        PRIMARY_PIXEL_COLUMN_NAME,
+        PRIMARY_ORDER_COLUMN_NAME,
         PRIMARY_PIXEL_COLUMN_NAME,
         JOIN_ORDER_COLUMN_NAME,
         JOIN_PIXEL_COLUMN_NAME,
@@ -30,8 +39,82 @@ class PartitionJoinInfo:
             if column not in self.data_frame.columns:
                 raise ValueError(f"join_info_df does not contain column {column}")
 
+    def primary_to_join_map(self) -> Dict[HealpixPixel, List[HealpixPixel]]:
+        """Generate a map from a single primary pixel to one or more pixels in the join catalog.
+
+        Lots of cute comprehension is happening here, so watch out!
+        We create tuple of (primary order/pixel) and [array of tuples of (join order/pixel)]
+        """
+        primary_map = self.data_frame.groupby(
+            [self.PRIMARY_ORDER_COLUMN_NAME, self.PRIMARY_PIXEL_COLUMN_NAME], group_keys=True
+        )
+        primary_to_join = [
+            (
+                HealpixPixel(int(primary_pixel[0]), int(primary_pixel[1])),
+                [
+                    HealpixPixel(int(object_elem[0]), int(object_elem[1]))
+                    for object_elem in join_group.dropna().to_numpy().T[2:4].T
+                ],
+            )
+            for primary_pixel, join_group in primary_map
+        ]
+        ## Treat the array of tuples as a dictionary.
+        primary_to_join = dict(primary_to_join)
+        return primary_to_join
+
+    def write_to_metadata_files(self, catalog_path: FilePointer, storage_options: dict = None):
+        """Generate parquet metadata, using the known partitions.
+
+        Args:
+            catalog_path (FilePointer): base path for the catalog
+            storage_options (dict): dictionary that contains abstract filesystem credentials
+        """
+        batches = [
+            [
+                pa.RecordBatch.from_arrays(
+                    [
+                        [primary_pixel.order],
+                        [primary_pixel.pixel],
+                        [join_pixel.order],
+                        [join_pixel.pixel],
+                    ],
+                    names=self.COLUMN_NAMES,
+                )
+                for join_pixel in join_pixels
+            ]
+            for primary_pixel, join_pixels in self.primary_to_join_map().items()
+        ]
+
+        write_parquet_metadata_for_batches(batches, catalog_path, storage_options)
+
     @classmethod
-    def read_from_file(
+    def read_from_file(cls, metadata_file: FilePointer, storage_options: Union[Dict[Any, Any], None] = None):
+        """Read partition join info from a `_metadata` file to create an object
+
+        Args:
+            metadata_file: FilePointer to the `_metadata` file
+            storage_options: dictionary that contains abstract filesystem credentials
+
+        Returns:
+            A `PartitionJoinInfo` object with the data from the file
+        """
+        pixel_frame = pd.DataFrame(
+            [
+                (
+                    row_group_stat_single_value(row_group, cls.PRIMARY_ORDER_COLUMN_NAME),
+                    row_group_stat_single_value(row_group, cls.PRIMARY_PIXEL_COLUMN_NAME),
+                    row_group_stat_single_value(row_group, cls.JOIN_ORDER_COLUMN_NAME),
+                    row_group_stat_single_value(row_group, cls.JOIN_PIXEL_COLUMN_NAME),
+                )
+                for row_group in read_row_group_fragments(metadata_file, storage_options)
+            ],
+            columns=cls.COLUMN_NAMES,
+        )
+
+        return cls(pixel_frame)
+
+    @classmethod
+    def read_from_csv(
         cls, partition_join_info_file: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
     ) -> Self:
         """Read partition join info from a `partition_join_info.csv` file to create an object

--- a/tests/hipscat/catalog/association_catalog/test_partition_join_info.py
+++ b/tests/hipscat/catalog/association_catalog/test_partition_join_info.py
@@ -5,6 +5,7 @@ import pytest
 
 from hipscat.catalog.association_catalog.partition_join_info import PartitionJoinInfo
 from hipscat.io import file_io
+from hipscat.pixel_math.healpix_pixel import HealpixPixel
 
 
 def test_init(association_catalog_join_pixels):
@@ -20,9 +21,41 @@ def test_wrong_columns(association_catalog_join_pixels):
             PartitionJoinInfo(join_pixels)
 
 
-def test_read_from_file(association_catalog_partition_join_file, association_catalog_join_pixels):
-    file_pointer = file_io.get_file_pointer_from_path(association_catalog_partition_join_file)
+def test_read_from_metadata(association_catalog_join_pixels, association_catalog_path):
+    file_pointer = file_io.get_file_pointer_from_path(os.path.join(association_catalog_path, "_metadata"))
     info = PartitionJoinInfo.read_from_file(file_pointer)
+    pd.testing.assert_frame_equal(info.data_frame, association_catalog_join_pixels)
+
+
+def test_primary_to_join_map(association_catalog_join_pixels):
+    info = PartitionJoinInfo(association_catalog_join_pixels)
+    pd.testing.assert_frame_equal(info.data_frame, association_catalog_join_pixels)
+    pixel_map = info.primary_to_join_map()
+
+    expected = {
+        HealpixPixel(0, 11): [
+            HealpixPixel(1, 44),
+            HealpixPixel(1, 45),
+            HealpixPixel(1, 46),
+            HealpixPixel(1, 47),
+        ]
+    }
+    assert pixel_map == expected
+
+
+def test_metadata_file_round_trip(association_catalog_join_pixels, tmp_path):
+    info = PartitionJoinInfo(association_catalog_join_pixels)
+    pd.testing.assert_frame_equal(info.data_frame, association_catalog_join_pixels)
+    info.write_to_metadata_files(tmp_path)
+
+    file_pointer = file_io.get_file_pointer_from_path(os.path.join(tmp_path, "_metadata"))
+    new_info = PartitionJoinInfo.read_from_file(file_pointer)
+    pd.testing.assert_frame_equal(new_info.data_frame, association_catalog_join_pixels)
+
+
+def test_read_from_csv(association_catalog_partition_join_file, association_catalog_join_pixels):
+    file_pointer = file_io.get_file_pointer_from_path(association_catalog_partition_join_file)
+    info = PartitionJoinInfo.read_from_csv(file_pointer)
     pd.testing.assert_frame_equal(info.data_frame, association_catalog_join_pixels)
 
 
@@ -30,4 +63,4 @@ def test_read_from_missing_file(tmp_path):
     wrong_path = os.path.join(tmp_path, "wrong")
     file_pointer = file_io.get_file_pointer_from_path(wrong_path)
     with pytest.raises(FileNotFoundError):
-        PartitionJoinInfo.read_from_file(file_pointer)
+        PartitionJoinInfo.read_from_csv(file_pointer)


### PR DESCRIPTION
## Change Description

Addresses two points in issue #147:

- Load partition info from _metadata file by default (for association catalog)
- Don't require partition_info.csv file for catalog to be loaded from disk (for association catalog)