### PR TITLE
Remove smoke test against python 3.8

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Change Description

Remove python 3.8 as an option for smoke testing. It was already removed from other workflows, but this one was left out.