### PR TITLE
Optionally include protocol prefix in file match.

### DIFF
--- a/src/hipscat/io/file_io/file_pointer.py
+++ b/src/hipscat/io/file_io/file_pointer.py
@@ -154,25 +154,35 @@ def is_regular_file(pointer: FilePointer, storage_options: Union[Dict[Any, Any],
 
 
 def find_files_matching_path(
-    pointer: FilePointer, *paths: str, storage_options: Union[Dict[Any, Any], None] = None
+    pointer: FilePointer,
+    *paths: str,
+    include_protocol=False,
+    storage_options: Union[Dict[Any, Any], None] = None,
 ) -> List[FilePointer]:
     """Find files or directories matching the provided path parts.
 
     Args:
+        pointer: base File Pointer in which to find contents
         paths: any number of directory names optionally followed by a file name.
             directory or file names may be replaced with `*` as a matcher.
+        include_protocol: boolean on whether or not to include the filesystem protocol in the
+            returned directory contents
         storage_options: dictionary that contains abstract filesystem credentials
     Returns:
         New file pointers to files found matching the path
     """
     matcher = append_paths_to_pointer(pointer, *paths)
-    file_system, pointer = get_fs(pointer, storage_options)
-    return [get_file_pointer_from_path(x) for x in file_system.glob(matcher)]
+    file_system, _ = get_fs(pointer, storage_options)
+
+    contents = [get_file_pointer_from_path(x) for x in file_system.glob(matcher)]
+
+    if include_protocol:
+        contents = [get_full_file_pointer(x, protocol_path=pointer) for x in contents]
+
+    return contents
 
 
-def directory_has_contents(
-    pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
-) -> bool:
+def directory_has_contents(pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None) -> bool:
     """Checks if a directory already has some contents (any files or subdirectories)
 
     Args:

--- a/tests/hipscat/io/file_io/test_file_pointers.py
+++ b/tests/hipscat/io/file_io/test_file_pointers.py
@@ -60,7 +60,14 @@ def test_is_regular_file(small_sky_dir):
 
 def test_find_files_matching_path(small_sky_dir):
     ## no_wildcard
-    assert len(find_files_matching_path(small_sky_dir, "catalog_info.json")) == 1
+    matching_files = find_files_matching_path(small_sky_dir, "catalog_info.json")
+    assert len(matching_files) == 1
+
+    matching_files_with_protocol = find_files_matching_path(
+        small_sky_dir, "catalog_info.json", include_protocol=True
+    )
+    assert matching_files_with_protocol[0] != matching_files[0]
+    assert matching_files[0] in matching_files_with_protocol[0]
 
     ## wilcard in the name
     assert len(find_files_matching_path(small_sky_dir, "*.json")) == 1


### PR DESCRIPTION
## Change Description

In service of https://github.com/astronomy-commons/hipscat-import/issues/177. Matching paths must also contain the original filesystem protocol in order to read the files.
