### PR TITLE
Sean/association table metadata

### DIFF
--- a/src/hipscat/catalog/association_catalog/association_catalog_info.py
+++ b/src/hipscat/catalog/association_catalog/association_catalog_info.py
@@ -31,10 +31,8 @@ class AssociationCatalogInfo(BaseCatalogInfo):
     required_fields = BaseCatalogInfo.required_fields + [
         "primary_catalog",
         "primary_column",
-        "primary_column_association",
         "join_catalog",
         "join_column",
-        "join_column_association",
     ]
 
     DEFAULT_TYPE = CatalogType.ASSOCIATION

--- a/src/hipscat/catalog/association_catalog/association_catalog_info.py
+++ b/src/hipscat/catalog/association_catalog/association_catalog_info.py
@@ -16,15 +16,25 @@ class AssociationCatalogInfo(BaseCatalogInfo):
     primary_column: str | None = None
     """Column name in the primary (left) side of join"""
 
+    primary_column_association: str | None = None
+    """Column name in the association table that matches the primary (left) side of join"""
+
     join_catalog: str | None = None
     """Catalog name for the joining (right) side of association"""
 
     join_column: str | None = None
     """Column name in the joining (right) side of join"""
 
+    join_column_association: str | None = None
+    """Column name in the association table that matches the joining (right) side of join"""
+
     required_fields = BaseCatalogInfo.required_fields + [
         "primary_catalog",
+        "primary_column",
+        "primary_column_association",
         "join_catalog",
+        "join_column",
+        "join_column_association",
     ]
 
     DEFAULT_TYPE = CatalogType.ASSOCIATION

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,8 +88,10 @@ def association_catalog_info_data() -> dict:
         "total_rows": 10,
         "primary_catalog": "small_sky",
         "primary_column": "id",
+        "primary_column_association": "id_small_sky",
         "join_catalog": "small_sky_order1",
         "join_column": "id",
+        "join_column_association": "id_small_sky_order1",
     }
 
 

--- a/tests/data/small_sky_to_small_sky_order1/catalog_info.json
+++ b/tests/data/small_sky_to_small_sky_order1/catalog_info.json
@@ -3,7 +3,9 @@
   "catalog_type": "association",
   "primary_catalog": "small_sky",
   "primary_column": "id",
+  "primary_column_association": "id_small_sky",
   "join_catalog": "small_sky_order1",
   "join_column": "id",
+  "join_column_association": "id_small_sky_order1",
   "total_rows": 131
 }


### PR DESCRIPTION

## Change Description

Updates Association table catalog info metadata to include extra fields to specify the joining columns names in the association table as separate names to the names in the original catalogs.

Updates required catalog_info fields now that we no longer use index joining with association tables.
