### PR TITLE
Add partition info load benchmarks.

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -17,7 +17,7 @@
     "build_command": [
         "python -m build --wheel -o {build_cache_dir} {build_dir}"
     ],
-    "default_benchmark_timeout": 180,
+    "default_benchmark_timeout": 300,
     // The DVCS being used. If not set, it will be automatically
     // determined from "repo" by looking at the protocol in the URL
     // (if remote), or by looking for special directories, such as

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -17,6 +17,7 @@
     "build_command": [
         "python -m build --wheel -o {build_cache_dir} {build_dir}"
     ],
+    "default_benchmark_timeout": 180,
     // The DVCS being used. If not set, it will be automatically
     // determined from "repo" by looking at the protocol in the URL
     // (if remote), or by looking for special directories, such as


### PR DESCRIPTION
## Change Description

In lieu of tests with real data under the hipscat-cloudtest repo. this adds benchmarks that generate large parquet metadata files and loads the partition data from them.

NB: This PR also adds the speed up to reading those `_metadata` files.

Stated benchmarks:

```
Before          After 	        Ratio
41.7±0.4s	1.83±0.01s	~0.04	benchmarks.MetadataSuite.time_load_partition_join_info
17.2±0.1s	1.12±0.01s	0.07	benchmarks.MetadataSuite.time_load_partition_info_order7
4.24±0.07s	271±2ms        	0.06	benchmarks.MetadataSuite.time_load_partition_info_order6
```