### PR TITLE
Update README.md- fix link to the LINCC logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.lsstcorporation.org/lincc/sites/default/files/PastedGraphic-8.png" width="300" height="100">
+<img src="https://github.com/lincc-frameworks/tape/blob/main/docs/DARK_Combo_sm.png?raw=true" width="300" height="100">
 
 # HiPSCat
 


### PR DESCRIPTION
## Change Description

See also https://github.com/astronomy-commons/lsdb/pull/91