### PR TITLE
Accept lists of coordinates for polygonal search

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "pandas",
     "pyarrow>=10.0.0",
     "typing-extensions>=4.3.0",
-    "spherical-geometry", # To handle spherical sky polygons
 ]
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)

--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -13,7 +13,11 @@ from hipscat.catalog.catalog_type import CatalogType
 from hipscat.catalog.healpix_dataset.healpix_dataset import HealpixDataset, PixelInputTypes
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.cone_filter import filter_pixels_by_cone
-from hipscat.pixel_math.polygon_filter import CartesianCoordinates, filter_pixels_by_polygon
+from hipscat.pixel_math.polygon_filter import (
+    CartesianCoordinates,
+    SphericalCoordinates,
+    filter_pixels_by_polygon,
+)
 from hipscat.pixel_tree.pixel_node_type import PixelNodeType
 
 
@@ -74,12 +78,14 @@ class Catalog(HealpixDataset):
         )
         return Catalog(filtered_catalog_info, filtered_cone_pixels)
 
-    def filter_by_polygon(self, vertices: List[CartesianCoordinates]) -> Catalog:
+    def filter_by_polygon(self, vertices: List[SphericalCoordinates] | List[CartesianCoordinates]) -> Catalog:
         """Filter the pixels in the catalog to only include the pixels that overlap
         with a polygonal sky region.
 
         Args:
-            vertices (List[CartesianCoordinates]): The vertices of the polygon to filter points with.
+            vertices (List[SphericalCoordinates] | List[CartesianCoordinates]): The vertices
+                of the polygon to filter points with, in lists of (ra,dec) or (x,y,z) points
+                on the unit sphere.
 
         Returns:
             A new catalog with only the pixels that overlap with the specified polygon.

--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, List, Union
 
 import healpy as hp
 import numpy as np
-from spherical_geometry.polygon import SingleSphericalPolygon
 from typing_extensions import TypeAlias
 
 from hipscat.catalog.catalog_info import CatalogInfo
@@ -14,7 +13,7 @@ from hipscat.catalog.catalog_type import CatalogType
 from hipscat.catalog.healpix_dataset.healpix_dataset import HealpixDataset, PixelInputTypes
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.cone_filter import filter_pixels_by_cone
-from hipscat.pixel_math.polygon_filter import filter_pixels_by_polygon
+from hipscat.pixel_math.polygon_filter import PolygonVertices, filter_pixels_by_polygon
 from hipscat.pixel_tree.pixel_node_type import PixelNodeType
 
 
@@ -75,17 +74,17 @@ class Catalog(HealpixDataset):
         )
         return Catalog(filtered_catalog_info, filtered_cone_pixels)
 
-    def filter_by_polygon(self, polygon: SingleSphericalPolygon) -> Catalog:
+    def filter_by_polygon(self, vertices: PolygonVertices) -> Catalog:
         """Filter the pixels in the catalog to only include the pixels that overlap
         with a polygonal sky region.
 
         Args:
-            polygon (SingleSphericalPolygon): The polygon to filter points with
+            vertices (PolygonVertices): The vertices of the polygon to filter points with.
 
         Returns:
             A new catalog with only the pixels that overlap with the specified polygon.
         """
-        filtered_polygon_pixels = filter_pixels_by_polygon(self.pixel_tree, polygon)
+        filtered_polygon_pixels = filter_pixels_by_polygon(self.pixel_tree, vertices)
         filtered_catalog_info = dataclasses.replace(self.catalog_info, total_rows=None)
         return Catalog(filtered_catalog_info, filtered_polygon_pixels)
 

--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -13,7 +13,7 @@ from hipscat.catalog.catalog_type import CatalogType
 from hipscat.catalog.healpix_dataset.healpix_dataset import HealpixDataset, PixelInputTypes
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.cone_filter import filter_pixels_by_cone
-from hipscat.pixel_math.polygon_filter import PolygonVertices, filter_pixels_by_polygon
+from hipscat.pixel_math.polygon_filter import CartesianCoordinates, filter_pixels_by_polygon
 from hipscat.pixel_tree.pixel_node_type import PixelNodeType
 
 
@@ -74,12 +74,12 @@ class Catalog(HealpixDataset):
         )
         return Catalog(filtered_catalog_info, filtered_cone_pixels)
 
-    def filter_by_polygon(self, vertices: PolygonVertices) -> Catalog:
+    def filter_by_polygon(self, vertices: List[CartesianCoordinates]) -> Catalog:
         """Filter the pixels in the catalog to only include the pixels that overlap
         with a polygonal sky region.
 
         Args:
-            vertices (PolygonVertices): The vertices of the polygon to filter points with.
+            vertices (List[CartesianCoordinates]): The vertices of the polygon to filter points with.
 
         Returns:
             A new catalog with only the pixels that overlap with the specified polygon.

--- a/src/hipscat/pixel_math/polygon_filter.py
+++ b/src/hipscat/pixel_math/polygon_filter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Tuple, TypeAlias
 
 import healpy as hp
@@ -8,28 +10,34 @@ from hipscat.pixel_math.filter import get_filtered_pixel_list
 from hipscat.pixel_tree.pixel_tree import PixelTree
 from hipscat.pixel_tree.pixel_tree_builder import PixelTreeBuilder
 
-# Pair of sky coordinates (ra, dec)
-SkyCoordinates: TypeAlias = Tuple[float, float]
+# Pair of spherical sky coordinates (ra, dec)
+SphericalCoordinates: TypeAlias = Tuple[float, float]
 
 # Sky coordinates on the unit sphere, in cartesian representation (x,y,z)
 CartesianCoordinates: TypeAlias = Tuple[float, float, float]
 
 
 def filter_pixels_by_polygon(
-    pixel_tree: PixelTree, vertices: List[CartesianCoordinates]
+    pixel_tree: PixelTree,
+    vertices: List[SphericalCoordinates] | List[CartesianCoordinates]
 ) -> List[HealpixPixel]:
     """Filter the leaf pixels in a pixel tree to return a list of healpix pixels that
     overlap with a polygonal region.
 
     Args:
         pixel_tree (PixelTree): The catalog tree to filter pixels from.
-        vertices (List[CartesianCoordinates]): The vertices of the polygon to filter pixels
-            with, in cartesian representation, with shape (Num vertices, 3).
+        vertices (List[SphericalCoordinates] | List[CartesianCoordinates]): The vertices
+            of the polygon to filter points with, in lists of (ra,dec) or (x,y,z) points
+            on the unit sphere.
 
     Returns:
         List of HealpixPixel, representing only the pixels that overlap
         with the specified polygonal region, and the maximum pixel order.
     """
+    # Get the coordinates vector on the unit sphere if we were provided
+    # with polygon spherical coordinates of ra and dec
+    if all(len(vertex) == 2 for vertex in vertices):
+        vertices = hp.ang2vec(*np.array(vertices).T, lonlat=True)
     max_order = max(pixel_tree.pixels.keys())
     polygon_tree = _generate_polygon_pixel_tree(vertices, max_order)
     return get_filtered_pixel_list(pixel_tree, polygon_tree)

--- a/src/hipscat/pixel_math/polygon_filter.py
+++ b/src/hipscat/pixel_math/polygon_filter.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import List, Tuple, TypeAlias
+from typing import List, Tuple
 
 import healpy as hp
 import numpy as np
+from typing_extensions import TypeAlias
 
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.filter import get_filtered_pixel_list

--- a/src/hipscat/pixel_math/polygon_filter.py
+++ b/src/hipscat/pixel_math/polygon_filter.py
@@ -1,33 +1,32 @@
-from typing import List
+from typing import List, Tuple, TypeAlias
 
 import healpy as hp
 import numpy as np
-from spherical_geometry.polygon import SingleSphericalPolygon
 
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.filter import get_filtered_pixel_list
 from hipscat.pixel_tree.pixel_tree import PixelTree
 from hipscat.pixel_tree.pixel_tree_builder import PixelTreeBuilder
 
+# The vertices of the polygon on the unit sphere, in cartesian representation (x,y,z)
+PolygonVertices: TypeAlias = List[Tuple[float, float, float]]
 
-def filter_pixels_by_polygon(pixel_tree: PixelTree, polygon: SingleSphericalPolygon) -> List[HealpixPixel]:
-    """Filter the leaf pixels in a pixel tree to return a list of
-    healpix pixels that overlap with a polygonal region.
+
+def filter_pixels_by_polygon(pixel_tree: PixelTree, vertices: PolygonVertices) -> List[HealpixPixel]:
+    """Filter the leaf pixels in a pixel tree to return a list of healpix pixels that
+    overlap with a polygonal region.
 
     Args:
-        pixel_tree (PixelTree): The catalog tree to filter pixels from
-        polygon (SingleSphericalPolygon): The polygon to filter pixels with
+        pixel_tree (PixelTree): The catalog tree to filter pixels from.
+        vertices (PolygonVertices): The vertices of the polygon to filter pixels
+            with, in cartesian representation, with shape (Num vertices, 3).
 
     Returns:
         List of HealpixPixel, representing only the pixels that overlap
         with the specified polygonal region, and the maximum pixel order.
     """
     max_order = max(pixel_tree.pixels.keys())
-    # The SingleSphericalPolygon is an explicitly closed polygon, meaning
-    # that the first and last vertices are the same. Only the first of the
-    # repeated vertices is kept.
-    cartesian_vertices = np.array(list(polygon.points))[:-1]
-    polygon_tree = _generate_polygon_pixel_tree(cartesian_vertices, max_order)
+    polygon_tree = _generate_polygon_pixel_tree(vertices, max_order)
     return get_filtered_pixel_list(pixel_tree, polygon_tree)
 
 

--- a/src/hipscat/pixel_math/polygon_filter.py
+++ b/src/hipscat/pixel_math/polygon_filter.py
@@ -8,17 +8,22 @@ from hipscat.pixel_math.filter import get_filtered_pixel_list
 from hipscat.pixel_tree.pixel_tree import PixelTree
 from hipscat.pixel_tree.pixel_tree_builder import PixelTreeBuilder
 
-# The vertices of the polygon on the unit sphere, in cartesian representation (x,y,z)
-PolygonVertices: TypeAlias = List[Tuple[float, float, float]]
+# Pair of sky coordinates (ra, dec)
+SkyCoordinates: TypeAlias = Tuple[float, float]
+
+# Sky coordinates on the unit sphere, in cartesian representation (x,y,z)
+CartesianCoordinates: TypeAlias = Tuple[float, float, float]
 
 
-def filter_pixels_by_polygon(pixel_tree: PixelTree, vertices: PolygonVertices) -> List[HealpixPixel]:
+def filter_pixels_by_polygon(
+    pixel_tree: PixelTree, vertices: List[CartesianCoordinates]
+) -> List[HealpixPixel]:
     """Filter the leaf pixels in a pixel tree to return a list of healpix pixels that
     overlap with a polygonal region.
 
     Args:
         pixel_tree (PixelTree): The catalog tree to filter pixels from.
-        vertices (PolygonVertices): The vertices of the polygon to filter pixels
+        vertices (List[CartesianCoordinates]): The vertices of the polygon to filter pixels
             with, in cartesian representation, with shape (Num vertices, 3).
 
     Returns:


### PR DESCRIPTION
It removes the need for the `spherical-geometry` dependency on hipscat, as part of the migration to the `sphgeom`library. It also changes the interface to accept as input the lists of vertices instead of a pre-instantiated polygon object. Relates to https://github.com/astronomy-commons/lsdb/issues/84. Closes #177. 

- [X] My PR includes a link to the issue that I am addressing

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation