### PR TITLE
Consolidating some pixel list logic

### DIFF
--- a/src/hipscat/pixel_math/cone_filter.py
+++ b/src/hipscat/pixel_math/cone_filter.py
@@ -21,7 +21,7 @@ def filter_pixels_by_cone(pixel_tree: PixelTree, ra: float, dec: float, radius: 
     Returns:
         List of HealpixPixels representing only the pixels that overlap with the specified cone.
     """
-    max_order = max(pixel_tree.pixels.keys())
+    max_order = pixel_tree.get_max_depth()
     cone_tree = _generate_cone_pixel_tree(ra, dec, radius, max_order)
     return get_filtered_pixel_list(pixel_tree, cone_tree)
 

--- a/src/hipscat/pixel_math/polygon_filter.py
+++ b/src/hipscat/pixel_math/polygon_filter.py
@@ -38,7 +38,7 @@ def filter_pixels_by_polygon(
     # with polygon spherical coordinates of ra and dec
     if all(len(vertex) == 2 for vertex in vertices):
         vertices = hp.ang2vec(*np.array(vertices).T, lonlat=True)
-    max_order = max(pixel_tree.pixels.keys())
+    max_order = pixel_tree.get_max_depth()
     polygon_tree = _generate_polygon_pixel_tree(vertices, max_order)
     return get_filtered_pixel_list(pixel_tree, polygon_tree)
 

--- a/tests/hipscat/pixel_tree/test_pixel_tree.py
+++ b/tests/hipscat/pixel_tree/test_pixel_tree.py
@@ -17,6 +17,12 @@ def test_pixel_tree_length():
         assert len(tree) == length + 1
 
 
+def test_pixel_tree_max_depth(pixel_tree_1, pixel_tree_2, pixel_tree_3):
+    assert pixel_tree_1.get_max_depth() == 0
+    assert pixel_tree_2.get_max_depth() == 2
+    assert pixel_tree_3.get_max_depth() == 1
+
+
 def test_pixel_tree_contains():
     root_node = PixelNode((-1, -1), PixelNodeType.ROOT, None)
     leaf_node = PixelNode((0, 0), PixelNodeType.LEAF, root_node)


### PR DESCRIPTION
This is a collection of small refactors, related to https://github.com/astronomy-commons/lsdb/issues/108

- Unifies the logic to filter a `Catalog` object to a list of pixels, as the catalog info resetting stage is shared (and kind of fiddly) (and it's required for https://github.com/astronomy-commons/lsdb/pull/116)
- Creates a `PixelTree.get_max_depth` method, and moves several callsites to the shared method.
- Allows us to move all of the interesting logic in `generate_negative_tree_pixels` on to the `PixelTree` class, and so isolate more of the healpix logic into the `pixel_math` module.