### PR TITLE
Validate coordinates for catalog searches

### DIFF
--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -18,7 +18,7 @@ from hipscat.pixel_math.polygon_filter import (
     SphericalCoordinates,
     filter_pixels_by_polygon,
 )
-from hipscat.pixel_math.validators import validate_declination_values
+from hipscat.pixel_math.validators import validate_declination_values, validate_radius
 
 
 class Catalog(HealpixDataset):
@@ -71,6 +71,7 @@ class Catalog(HealpixDataset):
         Returns:
             A new catalog with only the pixels that overlap with the specified cone
         """
+        validate_radius(radius)
         validate_declination_values(dec)
         return self.filter_from_pixel_list(filter_pixels_by_cone(self.pixel_tree, ra, dec, radius))
 

--- a/src/hipscat/pixel_math/polygon_filter.py
+++ b/src/hipscat/pixel_math/polygon_filter.py
@@ -19,25 +19,20 @@ CartesianCoordinates: TypeAlias = Tuple[float, float, float]
 
 
 def filter_pixels_by_polygon(
-    pixel_tree: PixelTree, vertices: List[SphericalCoordinates] | List[CartesianCoordinates]
+    pixel_tree: PixelTree, vertices: List[CartesianCoordinates]
 ) -> List[HealpixPixel]:
     """Filter the leaf pixels in a pixel tree to return a list of healpix pixels that
     overlap with a polygonal region.
 
     Args:
         pixel_tree (PixelTree): The catalog tree to filter pixels from.
-        vertices (List[SphericalCoordinates] | List[CartesianCoordinates]): The vertices
-            of the polygon to filter points with, in lists of (ra,dec) or (x,y,z) points
-            on the unit sphere.
+        vertices (List[CartesianCoordinates]): The vertices of the polygon to filter points
+            with, in lists of (x,y,z) points on the unit sphere.
 
     Returns:
         List of HealpixPixel, representing only the pixels that overlap
         with the specified polygonal region, and the maximum pixel order.
     """
-    # Get the coordinates vector on the unit sphere if we were provided
-    # with polygon spherical coordinates of ra and dec
-    if all(len(vertex) == 2 for vertex in vertices):
-        vertices = hp.ang2vec(*np.array(vertices).T, lonlat=True)
     max_order = pixel_tree.get_max_depth()
     polygon_tree = _generate_polygon_pixel_tree(vertices, max_order)
     return get_filtered_pixel_list(pixel_tree, polygon_tree)

--- a/src/hipscat/pixel_math/validators.py
+++ b/src/hipscat/pixel_math/validators.py
@@ -9,6 +9,20 @@ import numpy as np
 class ValidatorsErrors(str, Enum):
     """Error messages for the coordinate validators"""
     INVALID_DEC = "declination must be in the -90.0 to 90.0 degree range"
+    INVALID_RADIUS = "cone radius must be positive"
+
+
+def validate_radius(radius: float):
+    """Validates that a cone search radius is positive
+
+    Arguments:
+        radius (float): The cone radius, in degrees
+
+    Raises:
+        ValueError if radius is non-positive
+    """
+    if radius <= 0:
+        raise ValueError(ValidatorsErrors.INVALID_RADIUS.value)
 
 
 def validate_declination_values(dec: float | List[float]):

--- a/src/hipscat/pixel_math/validators.py
+++ b/src/hipscat/pixel_math/validators.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import List
+
+import numpy as np
+
+
+def validate_declination_values(dec: float | List[float]):
+    """Validates that declination values are in the [-90,90] degree range
+
+    Arguments:
+        dec (float | List[float]): The declination values to be validated
+
+    Raises:
+        ValueError if declination values are not in the [-90,90] degree range
+    """
+    dec_values = np.array(dec)
+    lower_bound, upper_bound = -90., 90.
+    if not np.all((dec_values >= lower_bound) & (dec_values <= upper_bound)):
+        raise ValueError(f"declination must be in the [{lower_bound}, {upper_bound}] degree range")

--- a/src/hipscat/pixel_math/validators.py
+++ b/src/hipscat/pixel_math/validators.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from enum import Enum
 from typing import List
 
 import numpy as np
+
+
+class ValidatorsErrors(str, Enum):
+    """Error messages for the coordinate validators"""
+    INVALID_DEC = "declination must be in the -90.0 to 90.0 degree range"
 
 
 def validate_declination_values(dec: float | List[float]):
@@ -17,4 +23,4 @@ def validate_declination_values(dec: float | List[float]):
     dec_values = np.array(dec)
     lower_bound, upper_bound = -90., 90.
     if not np.all((dec_values >= lower_bound) & (dec_values <= upper_bound)):
-        raise ValueError(f"declination must be in the [{lower_bound}, {upper_bound}] degree range")
+        raise ValueError(ValidatorsErrors.INVALID_DEC.value)

--- a/tests/hipscat/catalog/test_catalog.py
+++ b/tests/hipscat/catalog/test_catalog.py
@@ -138,6 +138,8 @@ def test_cone_filter_invalid_cone_center(small_sky_order1_catalog):
         small_sky_order1_catalog.filter_by_cone(0, -100, 0.1)
     with pytest.raises(ValueError, match=ValidatorsErrors.INVALID_DEC):
         small_sky_order1_catalog.filter_by_cone(0, 100, 0.1)
+    with pytest.raises(ValueError, match=ValidatorsErrors.INVALID_RADIUS):
+        small_sky_order1_catalog.filter_by_cone(0, 10, -1)
 
 
 def test_polygonal_filter(small_sky_order1_catalog):

--- a/tests/hipscat/catalog/test_catalog.py
+++ b/tests/hipscat/catalog/test_catalog.py
@@ -1,6 +1,7 @@
 """Tests of catalog functionality"""
 
 import os
+import re
 
 import healpy as hp
 import numpy as np
@@ -132,6 +133,14 @@ def test_cone_filter_empty(small_sky_order1_catalog):
     assert len(filtered_catalog.pixel_tree) == 1
 
 
+def test_cone_filter_invalid_cone_center(small_sky_order1_catalog):
+    error_msg = re.escape("declination must be in the [-90.0, 90.0] degree range")
+    with pytest.raises(ValueError, match=error_msg):
+        small_sky_order1_catalog.filter_by_cone(0, -100, 0.1)
+    with pytest.raises(ValueError, match=error_msg):
+        small_sky_order1_catalog.filter_by_cone(0, 100, 0.1)
+
+
 def test_polygonal_filter(small_sky_order1_catalog):
     polygon_vertices = [(282, -58), (282, -55), (272, -55), (272, -58)]
     filtered_catalog = small_sky_order1_catalog.filter_by_polygon(polygon_vertices)
@@ -182,12 +191,15 @@ def test_polygonal_filter_empty(small_sky_order1_catalog):
     assert len(filtered_catalog.pixel_tree) == 1
 
 
-def test_polygonal_filter_invalid_shape(small_sky_order1_catalog):
-    # Polygon is not convex, so the shape is invalid
-    polygon_vertices = [(0, 1), (1, 0), (1, 1), (0, 0)]
-    with pytest.raises(RuntimeError):
+def test_polygonal_filter_invalid_polygon_coordinates(small_sky_order1_catalog):
+    # Declination is over 90 degrees
+    error_msg = re.escape("declination must be in the [-90.0, 90.0] degree range")
+    polygon_vertices = [(47.1, -100), (64.5, -100), (64.5, 6.27), (47.1, 6.27)]
+    with pytest.raises(ValueError, match=error_msg):
         small_sky_order1_catalog.filter_by_polygon(polygon_vertices)
-
+    # Right ascension should wrap, it does not throw an error
+    polygon_vertices = [(470.1, 6), (470.5, 6), (64.5, 10.27), (47.1, 10.27)]
+    small_sky_order1_catalog.filter_by_polygon(polygon_vertices)
 
 def test_empty_directory(tmp_path):
     """Test loading empty or incomplete data"""

--- a/tests/hipscat/catalog/test_catalog.py
+++ b/tests/hipscat/catalog/test_catalog.py
@@ -1,7 +1,6 @@
 """Tests of catalog functionality"""
 
 import os
-import re
 
 import healpy as hp
 import numpy as np
@@ -9,6 +8,7 @@ import pytest
 
 from hipscat.catalog import Catalog, CatalogType, PartitionInfo
 from hipscat.pixel_math import HealpixPixel
+from hipscat.pixel_math.validators import ValidatorsErrors
 from hipscat.pixel_tree.pixel_node_type import PixelNodeType
 from hipscat.pixel_tree.pixel_tree_builder import PixelTreeBuilder
 
@@ -134,10 +134,9 @@ def test_cone_filter_empty(small_sky_order1_catalog):
 
 
 def test_cone_filter_invalid_cone_center(small_sky_order1_catalog):
-    error_msg = re.escape("declination must be in the [-90.0, 90.0] degree range")
-    with pytest.raises(ValueError, match=error_msg):
+    with pytest.raises(ValueError, match=ValidatorsErrors.INVALID_DEC):
         small_sky_order1_catalog.filter_by_cone(0, -100, 0.1)
-    with pytest.raises(ValueError, match=error_msg):
+    with pytest.raises(ValueError, match=ValidatorsErrors.INVALID_DEC):
         small_sky_order1_catalog.filter_by_cone(0, 100, 0.1)
 
 
@@ -193,13 +192,13 @@ def test_polygonal_filter_empty(small_sky_order1_catalog):
 
 def test_polygonal_filter_invalid_polygon_coordinates(small_sky_order1_catalog):
     # Declination is over 90 degrees
-    error_msg = re.escape("declination must be in the [-90.0, 90.0] degree range")
     polygon_vertices = [(47.1, -100), (64.5, -100), (64.5, 6.27), (47.1, 6.27)]
-    with pytest.raises(ValueError, match=error_msg):
+    with pytest.raises(ValueError, match=ValidatorsErrors.INVALID_DEC):
         small_sky_order1_catalog.filter_by_polygon(polygon_vertices)
     # Right ascension should wrap, it does not throw an error
     polygon_vertices = [(470.1, 6), (470.5, 6), (64.5, 10.27), (47.1, 10.27)]
     small_sky_order1_catalog.filter_by_polygon(polygon_vertices)
+
 
 def test_empty_directory(tmp_path):
     """Test loading empty or incomplete data"""


### PR DESCRIPTION
Moves the validators of input coordinates to hipscat (for cone search radius and cone / polygon search declination values). Related to changes on https://github.com/astronomy-commons/lsdb/pull/117.

- [X] My PR includes a link to the issue that I am addressing

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation