### PR TITLE
Check for polygon degeneracy

### DIFF
--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -18,7 +18,7 @@ from hipscat.pixel_math.polygon_filter import (
     SphericalCoordinates,
     filter_pixels_by_polygon,
 )
-from hipscat.pixel_math.validators import validate_declination_values, validate_radius
+from hipscat.pixel_math.validators import validate_declination_values, validate_polygon, validate_radius
 
 
 class Catalog(HealpixDataset):
@@ -93,6 +93,7 @@ class Catalog(HealpixDataset):
             # Get the coordinates vector on the unit sphere if we were provided
             # with polygon spherical coordinates of ra and dec
             vertices = hp.ang2vec(ra, dec, lonlat=True)
+        validate_polygon(vertices)
         return self.filter_from_pixel_list(filter_pixels_by_polygon(self.pixel_tree, vertices))
 
     def filter_from_pixel_list(self, pixels: List[HealpixPixel]) -> Catalog:


### PR DESCRIPTION
Adds some additional validation to the catalog search using polygons. In particular, this change makes sure that polygons provided by the user are not degenerate, preventing some invalid calls to healpy's `query_polygon`. This is part of issue https://github.com/astronomy-commons/lsdb/issues/120.

- [X] My PR includes a link to the issue that I am addressing

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation