### PR TITLE
Pin version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "healpy",
     "numba",
     "pandas",
-    "pyarrow>=10.0.0",
+    "pyarrow>=14.0.1",
     "typing-extensions>=4.3.0",
 ]
 


### PR DESCRIPTION
## Change Description

Closes #204 

## Solution Description

Pins version of pyarrow to avoid known security issue. This should propagate to other packages depending on hipscat.