### PR TITLE
Support pathlib in json encoding

### DIFF
--- a/src/hipscat/io/write_metadata.py
+++ b/src/hipscat/io/write_metadata.py
@@ -24,7 +24,7 @@ class HipscatEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, Path):
             return str(o)
-        return super().default(self, o)  # pragma: no cover
+        return super().default(o)  # pragma: no cover
 
 
 def write_json_file(

--- a/src/hipscat/io/write_metadata.py
+++ b/src/hipscat/io/write_metadata.py
@@ -4,6 +4,7 @@ import dataclasses
 import json
 from datetime import datetime
 from importlib.metadata import version
+from pathlib import Path
 from typing import Any, Dict, Union
 
 import numpy as np
@@ -11,6 +12,15 @@ import pandas as pd
 
 from hipscat.io import file_io, paths
 from hipscat.io.parquet_metadata import write_parquet_metadata as wpm
+
+
+class HipscatEncoder(json.JSONEncoder):
+    """Special json encoder for types commonly encountered with hipscat"""
+
+    def default(self, o):
+        if isinstance(o, Path):
+            return str(o)
+        return json.JSONEncoder.default(self, o)
 
 
 def write_json_file(
@@ -25,7 +35,7 @@ def write_json_file(
         file_pointer (str): destination for the json file
         storage_options: dictionary that contains abstract filesystem credentials
     """
-    dumped_metadata = json.dumps(metadata_dictionary, indent=4)
+    dumped_metadata = json.dumps(metadata_dictionary, indent=4, cls=HipscatEncoder)
     file_io.write_string_to_file(file_pointer, dumped_metadata + "\n", storage_options=storage_options)
 
 

--- a/src/hipscat/io/write_metadata.py
+++ b/src/hipscat/io/write_metadata.py
@@ -15,12 +15,16 @@ from hipscat.io.parquet_metadata import write_parquet_metadata as wpm
 
 
 class HipscatEncoder(json.JSONEncoder):
-    """Special json encoder for types commonly encountered with hipscat"""
+    """Special json encoder for types commonly encountered with hipscat.
+
+    NB: This will only be used by JSON encoding when encountering a type
+    that is unhandled by the default encoder.
+    """
 
     def default(self, o):
         if isinstance(o, Path):
             return str(o)
-        return json.JSONEncoder.default(self, o)
+        return super().default(self, o)  # pragma: no cover
 
 
 def write_json_file(

--- a/tests/hipscat/io/test_write_metadata.py
+++ b/tests/hipscat/io/test_write_metadata.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+from pathlib import Path
 
 import numpy.testing as npt
 
@@ -35,6 +36,25 @@ def test_write_json_file(assert_text_file_matches, tmp_path):
     dictionary["first_number"] = 1
     dictionary["first_five_fib"] = [1, 1, 2, 3, 5]
 
+    json_filename = os.path.join(tmp_path, "dictionary.json")
+    io.write_json_file(dictionary, json_filename)
+    assert_text_file_matches(expected_lines, json_filename)
+
+
+def test_write_json_paths(assert_text_file_matches, tmp_path):
+    posix_path = Path(tmp_path)
+    file_pointer = file_io.FilePointer(tmp_path)
+    dictionary = {}
+    dictionary["posix_path"] = posix_path
+    dictionary["file_pointer"] = file_pointer
+    dictionary["first_greek"] = "alpha"
+    expected_lines = [
+        "{\n",
+        f'    "posix_path": "{tmp_path}",',
+        f'    "file_pointer": "{tmp_path}",',
+        '    "first_greek": "alpha"',
+        "}",
+    ]
     json_filename = os.path.join(tmp_path, "dictionary.json")
     io.write_json_file(dictionary, json_filename)
     assert_text_file_matches(expected_lines, json_filename)

--- a/tests/hipscat/io/test_write_metadata.py
+++ b/tests/hipscat/io/test_write_metadata.py
@@ -42,15 +42,15 @@ def test_write_json_file(assert_text_file_matches, tmp_path):
 
 
 def test_write_json_paths(assert_text_file_matches, tmp_path):
-    posix_path = Path(tmp_path)
+    pathlib_path = Path(tmp_path)
     file_pointer = file_io.FilePointer(tmp_path)
     dictionary = {}
-    dictionary["posix_path"] = posix_path
+    dictionary["pathlib_path"] = pathlib_path
     dictionary["file_pointer"] = file_pointer
     dictionary["first_greek"] = "alpha"
     expected_lines = [
         "{\n",
-        f'    "posix_path": "{tmp_path}",',
+        f'    "pathlib_path": "{tmp_path}",',
         f'    "file_pointer": "{tmp_path}",',
         '    "first_greek": "alpha"',
         "}",


### PR DESCRIPTION
## Change Description

Related to three downstream issues:
- https://github.com/astronomy-commons/hipscat-import/issues/228
- https://github.com/astronomy-commons/hipscat-import/issues/160
- https://github.com/astronomy-commons/lsdb/issues/169

This change will need to be in a tagged release before we can add tests in those repos and consider those issues closed.

## Solution Description

Adds a simple JSON encoder with a special case for pathlib.Path. Additional other types can be added there, if they cause problems in JSON writing.