### PR TITLE
Remove slow right ascension wrapping call

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -40,7 +40,7 @@ def time_test_cone_filter_multiple_order():
     )
     pixels = [HealpixPixel(6, 30), HealpixPixel(7, 124), HealpixPixel(7, 5000)]
     catalog = Catalog(catalog_info, pixels)
-    filtered_catalog = catalog.filter_by_cone(47.1, 6, 30)
+    filtered_catalog = catalog.filter_by_cone(47.1, 6, 30 * 3600)
     assert filtered_catalog.get_healpix_pixels() == [HealpixPixel(6, 30), HealpixPixel(7, 124)]
 
 

--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -13,7 +13,7 @@ from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.catalog.catalog_type import CatalogType
 from hipscat.catalog.healpix_dataset.healpix_dataset import HealpixDataset, PixelInputTypes
 from hipscat.pixel_math import HealpixPixel
-from hipscat.pixel_math.box_filter import filter_pixels_by_box, wrap_ra_values
+from hipscat.pixel_math.box_filter import filter_pixels_by_box, wrap_ra_angles
 from hipscat.pixel_math.cone_filter import filter_pixels_by_cone
 from hipscat.pixel_math.polygon_filter import (
     CartesianCoordinates,
@@ -96,7 +96,7 @@ class Catalog(HealpixDataset):
         Returns:
             A new catalog with only the pixels that overlap with the specified region
         """
-        ra = wrap_ra_values(ra)
+        ra = tuple(wrap_ra_angles(ra)) if ra else None
         validate_box_search(ra, dec)
         return self.filter_from_pixel_list(filter_pixels_by_box(self.pixel_tree, ra, dec))
 

--- a/src/hipscat/pixel_math/box_filter.py
+++ b/src/hipscat/pixel_math/box_filter.py
@@ -49,20 +49,7 @@ def filter_pixels_by_box(
     return result_pixels
 
 
-def wrap_ra_values(ra: Tuple[float, float] | None) -> Tuple[float, float] | None:
-    """Wraps right ascension values to the [0,360] degree range.
-
-    Args:
-        ra (Tuple[float, float]): The right ascension values, in degrees
-
-    Returns:
-        The right ascension values wrapped to the [0,360] degree range,
-        or None if they do not exist.
-    """
-    return tuple(wrap_angles(ra)) if ra else None
-
-
-def wrap_angles(ra: np.ndarray | Iterable | int | float) -> np.ndarray:
+def wrap_ra_angles(ra: np.ndarray | Iterable | int | float) -> np.ndarray:
     """Wraps angles to the [0,360] degree range.
 
     Args:

--- a/src/hipscat/pixel_math/box_filter.py
+++ b/src/hipscat/pixel_math/box_filter.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import Iterable, List, Tuple
 
-import astropy.units as u
 import healpy as hp
 import numpy as np
-from astropy.coordinates import Angle
 
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.filter import get_filtered_pixel_list
@@ -61,19 +59,19 @@ def wrap_ra_values(ra: Tuple[float, float] | None) -> Tuple[float, float] | None
         The right ascension values wrapped to the [0,360] degree range,
         or None if they do not exist.
     """
-    return tuple(wrap_angles(list(ra))) if ra else None
+    return tuple(wrap_angles(ra)) if ra else None
 
 
-def wrap_angles(ra: List[float]) -> List[float]:
+def wrap_angles(ra: np.ndarray | Iterable | int | float) -> np.ndarray:
     """Wraps angles to the [0,360] degree range.
 
-    Arguments:
-        ra (List[float]): List of right ascension values
+    Args:
+        ra (ndarray | Iterable | int | float): Right ascension values, in degrees
 
     Returns:
-        A list of right ascension values, wrapped to the [0,360] degree range.
+        A numpy array of right ascension values, wrapped to the [0,360] degree range.
     """
-    return Angle(ra, u.deg).wrap_at(360 * u.deg).degree
+    return np.asarray(ra, dtype=float) % 360
 
 
 def _generate_ra_strip_pixel_tree(ra_range: Tuple[float, float], order: int) -> PixelTree:

--- a/src/hipscat/pixel_math/validators.py
+++ b/src/hipscat/pixel_math/validators.py
@@ -20,7 +20,7 @@ class ValidatorsErrors(str, Enum):
 def validate_radius(radius_arcsec: float):
     """Validates that a cone search radius is positive
 
-    Arguments:
+    Args:
         radius_arcsec (float): The cone radius, in arcseconds
 
     Raises:
@@ -33,7 +33,7 @@ def validate_radius(radius_arcsec: float):
 def validate_declination_values(dec: float | List[float]):
     """Validates that declination values are in the [-90,90] degree range
 
-    Arguments:
+    Args:
         dec (float | List[float]): The declination values to be validated
 
     Raises:
@@ -49,7 +49,7 @@ def validate_polygon(vertices: np.ndarray):
     """Checks if the polygon contain a minimum of three vertices, that they are
     unique and that the polygon does not fall on a great circle.
 
-    Arguments:
+    Args:
         vertices (np.ndarray): The polygon vertices, in cartesian coordinates
 
     Raises:
@@ -67,7 +67,7 @@ def is_polygon_degenerate(vertices: np.ndarray) -> bool:
     """Checks if all the vertices of the polygon are contained in a same plane.
     If the plane intersects the center of the sphere, the polygon is degenerate.
 
-    Arguments:
+    Args:
         vertices (np.ndarray): The polygon vertices, in cartesian coordinates
 
     Returns:
@@ -97,7 +97,7 @@ def validate_box_search(ra: Tuple[float, float] | None, dec: Tuple[float, float]
     - Declination values, if existing, must be in ascending order
     - Declination values, if existing, must be in the [-90,90] degree range
 
-    Arguments:
+    Args:
         ra (Tuple[float, float]): Right ascension range, in degrees
         dec (Tuple[float, float]): Declination range, in degrees
     """


### PR DESCRIPTION
Replaces the call to astropy's `wrap_at` with a simple vectorized numpy operation. Related to https://github.com/astronomy-commons/lsdb/issues/189. It also applies a very small fix to the `time_test_cone_filter_multiple_order` benchmark which started failing since the change of cone radius from degrees to arcseconds. 

- [X] My PR includes a link to the issue that I am addressing

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation