### PR TITLE
Refactor `filter_from_pixel_list` from `Catalog` to `HealpixDataset`

### DIFF
--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import dataclasses
 from typing import Any, Dict, List, Tuple, Union
 
 import healpy as hp
@@ -120,19 +119,6 @@ class Catalog(HealpixDataset):
             vertices = hp.ang2vec(ra, dec, lonlat=True)
         validate_polygon(vertices)
         return self.filter_from_pixel_list(filter_pixels_by_polygon(self.pixel_tree, vertices))
-
-    def filter_from_pixel_list(self, pixels: List[HealpixPixel]) -> Catalog:
-        """Filter the pixels in the catalog to only include the requested pixels.
-
-        Args:
-            pixels (List[HealpixPixels]): the pixels to include
-
-        Returns:
-            A new catalog with only those pixels. Note that we reset the total_rows
-            to None, instead of performing a scan over the new pixel sizes.
-        """
-        filtered_catalog_info = dataclasses.replace(self.catalog_info, total_rows=None)
-        return Catalog(filtered_catalog_info, pixels)
 
     def generate_negative_tree_pixels(self) -> List[HealpixPixel]:
         """Get the leaf nodes at each healpix order that have zero catalog data.

--- a/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
@@ -1,7 +1,8 @@
+import dataclasses
 from typing import Any, Dict, List, Tuple, Union
 
 import pandas as pd
-from typing_extensions import TypeAlias
+from typing_extensions import TypeAlias, Self
 
 from hipscat.catalog.dataset import BaseCatalogInfo, Dataset
 from hipscat.catalog.partition_info import PartitionInfo
@@ -102,3 +103,16 @@ class HealpixDataset(Dataset):
             raise FileNotFoundError(
                 f"_metadata or partition info file is required in catalog directory {catalog_base_dir}"
             )
+
+    def filter_from_pixel_list(self, pixels: List[HealpixPixel]) -> Self:
+        """Filter the pixels in the catalog to only include the requested pixels.
+
+        Args:
+            pixels (List[HealpixPixels]): the pixels to include
+
+        Returns:
+            A new catalog with only those pixels. Note that we reset the total_rows
+            to None, instead of performing a scan over the new pixel sizes.
+        """
+        filtered_catalog_info = dataclasses.replace(self.catalog_info, total_rows=None)
+        return self.__class__(filtered_catalog_info, pixels)

--- a/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
@@ -2,7 +2,7 @@ import dataclasses
 from typing import Any, Dict, List, Tuple, Union
 
 import pandas as pd
-from typing_extensions import TypeAlias, Self
+from typing_extensions import Self, TypeAlias
 
 from hipscat.catalog.dataset import BaseCatalogInfo, Dataset
 from hipscat.catalog.partition_info import PartitionInfo


### PR DESCRIPTION
To perform filtering on other types of catalogs such as margin catalogs, the `filter_from_pixel_list` method in the `Catalog` class needs to be refactored to be moved up into the `HealpixDataset` class.

## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->



## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

