### PR TITLE
Discrete values for legend in plot_pixels

### DIFF
--- a/src/hipscat/inspection/visualize_catalog.py
+++ b/src/hipscat/inspection/visualize_catalog.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Union
 import healpy as hp
 import numpy as np
 from matplotlib import pyplot as plt
+import matplotlib.colors as mcolors
 
 from hipscat.catalog import Catalog
 from hipscat.io import file_io, paths
@@ -82,6 +83,11 @@ def plot_pixel_list(pixels: List[HealpixPixel], plot_title: str = "", projection
             - orth - Orthographic projection
     """
     max_order = np.max(pixels).order
+    min_order = np.min(pixels).order
+
+    num_colors = max_order - min_order + 1
+    colors = plt.cm.viridis(np.linspace(0, 1, num_colors))
+    cmap = mcolors.LinearSegmentedColormap.from_list("my_colormap", colors, num_colors)
 
     order_map = np.full(hp.order2npix(max_order), hp.pixelfunc.UNSEEN)
 
@@ -98,17 +104,19 @@ def plot_pixel_list(pixels: List[HealpixPixel], plot_title: str = "", projection
         order_map,
         projection,
         plot_title,
-        draw_map=draw_map,
+        cmap=cmap,
+        draw_map=draw_map
     )
 
 
-def _plot_healpix_map(healpix_map, projection, title, draw_map=True):
+def _plot_healpix_map(healpix_map, projection, title, cmap="viridis", draw_map=True):
     """Perform the plotting of a healpix pixel map.
 
     Args:
         healpix_map: array containing the map
         projection: projection type to display
         title: title used in image plot
+        cmap: matplotlib colormap to use
     """
     if projection == "moll":
         projection_method = hp.mollview
@@ -126,5 +134,6 @@ def _plot_healpix_map(healpix_map, projection, title, draw_map=True):
             healpix_map,
             title=title,
             nest=True,
+            cmap=cmap,
         )
         plt.plot()

--- a/src/hipscat/inspection/visualize_catalog.py
+++ b/src/hipscat/inspection/visualize_catalog.py
@@ -86,12 +86,12 @@ def plot_pixel_list(pixels: List[HealpixPixel], plot_title: str = "", projection
     min_order = np.min(pixels).order
 
     if max_order == min_order:
-        color = plt.cm.viridis(0.5)
-        colors = [plt.cm.viridis(0.0), color]  # Create a list with gray and a single color
+        color = plt.cm.viridis(0.5)  # pylint: disable=no-member
+        colors = [plt.cm.viridis(0.0), color]  # pylint: disable=no-member
         cmap = mcolors.LinearSegmentedColormap.from_list("my_colormap", colors)
     else:
         num_colors = max_order - min_order + 1
-        colors = plt.cm.viridis(np.linspace(0, 1, num_colors)) # pylint: disable=no-member
+        colors = plt.cm.viridis(np.linspace(0, 1, num_colors))  # pylint: disable=no-member
         cmap = mcolors.LinearSegmentedColormap.from_list("my_colormap", colors, num_colors)
 
     order_map = np.full(hp.order2npix(max_order), hp.pixelfunc.UNSEEN)

--- a/src/hipscat/inspection/visualize_catalog.py
+++ b/src/hipscat/inspection/visualize_catalog.py
@@ -6,9 +6,9 @@ NB: Testing validity of generated plots is currently not tested in our unit test
 from typing import Any, Dict, List, Union
 
 import healpy as hp
+import matplotlib.colors as mcolors
 import numpy as np
 from matplotlib import pyplot as plt
-import matplotlib.colors as mcolors
 
 from hipscat.catalog import Catalog
 from hipscat.io import file_io, paths
@@ -100,13 +100,7 @@ def plot_pixel_list(pixels: List[HealpixPixel], plot_title: str = "", projection
             )
         ]
         order_map[exploded_pixels] = pixel.order
-    _plot_healpix_map(
-        order_map,
-        projection,
-        plot_title,
-        cmap=cmap,
-        draw_map=draw_map
-    )
+    _plot_healpix_map(order_map, projection, plot_title, cmap=cmap, draw_map=draw_map)
 
 
 def _plot_healpix_map(healpix_map, projection, title, cmap="viridis", draw_map=True):

--- a/src/hipscat/inspection/visualize_catalog.py
+++ b/src/hipscat/inspection/visualize_catalog.py
@@ -85,9 +85,14 @@ def plot_pixel_list(pixels: List[HealpixPixel], plot_title: str = "", projection
     max_order = np.max(pixels).order
     min_order = np.min(pixels).order
 
-    num_colors = max_order - min_order + 1
-    colors = plt.cm.viridis(np.linspace(0, 1, num_colors))
-    cmap = mcolors.LinearSegmentedColormap.from_list("my_colormap", colors, num_colors)
+    if max_order == min_order:
+        color = plt.cm.viridis(0.5)
+        colors = [plt.cm.viridis(0.0), color]  # Create a list with gray and a single color
+        cmap = mcolors.LinearSegmentedColormap.from_list("my_colormap", colors)
+    else:
+        num_colors = max_order - min_order + 1
+        colors = plt.cm.viridis(np.linspace(0, 1, num_colors)) # pylint: disable=no-member
+        cmap = mcolors.LinearSegmentedColormap.from_list("my_colormap", colors, num_colors)
 
     order_map = np.full(hp.order2npix(max_order), hp.pixelfunc.UNSEEN)
 


### PR DESCRIPTION
<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->

Makes the legend for plot_pixels function to have discreet values. Fixes [hipscat-218](https://github.com/astronomy-commons/hipscat/issues/218).

This is done by calculating the maximal and minimal order of the catalog and creating a custom (Segmented) colormap. This cmap is passed to underlying `_plot_healpix_map` function. When no custom colormap is given to  `_plot_healpix_map` it uses a default colormap ("viridis"), as it was the case until now.

There is a special case when max_order is the same as min_order. In this case, we create a two-tone cmap (gray + one color); this mimics the current behavior. I also had to disable pylint no-nember warning for plt.cm (e.g., similar problem as [here](https://stackoverflow.com/questions/67871510/module-matplotlib-cm-has-no-color-member) )



![new](https://github.com/astronomy-commons/hipscat/assets/12860669/3f9ae348-c688-4414-8953-bb83258b74e4)


- [X] My PR includes a link to the issue that I am addressing



## Solution Description


<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->



## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation


