### PR TITLE
Improve testing of visualization. Add kwargs.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "pylint", # Used for static linting of files
     "pytest",
     "pytest-cov", # Used to report total code coverage
+    "pytest-mock", # Used to mock objects in tests
     "pytest-timeout", # Used to test for code efficiency
     "s3fs", # s3 filesystem support
 ]

--- a/src/hipscat/inspection/visualize_catalog.py
+++ b/src/hipscat/inspection/visualize_catalog.py
@@ -28,7 +28,7 @@ def _read_point_map(catalog_base_dir, storage_options: Union[Dict[Any, Any], Non
     return file_io.read_fits_image(map_file_pointer, storage_options=storage_options)
 
 
-def plot_points(catalog: Catalog, projection="moll", draw_map=True):
+def plot_points(catalog: Catalog, projection="moll", **kwargs):
     """Create a visual map of the input points of an in-memory catalog.
 
     Args:
@@ -42,15 +42,10 @@ def plot_points(catalog: Catalog, projection="moll", draw_map=True):
     if not catalog.on_disk:
         raise ValueError("on disk catalog required for point-wise visualization")
     point_map = _read_point_map(catalog.catalog_base_dir, storage_options=catalog.storage_options)
-    _plot_healpix_map(
-        point_map,
-        projection,
-        f"Catalog point density map - {catalog.catalog_name}",
-        draw_map=draw_map,
-    )
+    _plot_healpix_map(point_map, projection, f"Catalog point density map - {catalog.catalog_name}", **kwargs)
 
 
-def plot_pixels(catalog: Catalog, projection="moll", draw_map=True):
+def plot_pixels(catalog: Catalog, projection="moll", **kwargs):
     """Create a visual map of the pixel density of the catalog.
 
     Args:
@@ -66,11 +61,11 @@ def plot_pixels(catalog: Catalog, projection="moll", draw_map=True):
         pixels=pixels,
         plot_title=f"Catalog pixel density map - {catalog.catalog_name}",
         projection=projection,
-        draw_map=draw_map,
+        **kwargs,
     )
 
 
-def plot_pixel_list(pixels: List[HealpixPixel], plot_title: str = "", projection="moll", draw_map=True):
+def plot_pixel_list(pixels: List[HealpixPixel], plot_title: str = "", projection="moll", **kwargs):
     """Create a visual map of the pixel density of a list of pixels.
 
     Args:
@@ -105,10 +100,10 @@ def plot_pixel_list(pixels: List[HealpixPixel], plot_title: str = "", projection
             )
         ]
         order_map[exploded_pixels] = pixel.order
-    _plot_healpix_map(order_map, projection, plot_title, cmap=cmap, draw_map=draw_map)
+    _plot_healpix_map(order_map, projection, plot_title, cmap=cmap, **kwargs)
 
 
-def _plot_healpix_map(healpix_map, projection, title, cmap="viridis", draw_map=True):
+def _plot_healpix_map(healpix_map, projection, title, cmap="viridis", **kwargs):
     """Perform the plotting of a healpix pixel map.
 
     Args:
@@ -128,11 +123,5 @@ def _plot_healpix_map(healpix_map, projection, title, cmap="viridis", draw_map=T
     else:
         raise NotImplementedError(f"unknown projection: {projection}")
 
-    if draw_map:  # pragma: no cover
-        projection_method(
-            healpix_map,
-            title=title,
-            nest=True,
-            cmap=cmap,
-        )
-        plt.plot()
+    projection_method(healpix_map, title=title, nest=True, cmap=cmap, **kwargs)
+    plt.plot()

--- a/tests/hipscat/inspection/test_visualize_catalog.py
+++ b/tests/hipscat/inspection/test_visualize_catalog.py
@@ -1,17 +1,49 @@
+import healpy as hp
 import pytest
 
 from hipscat.catalog import Catalog
 from hipscat.inspection import plot_pixel_list, plot_pixels, plot_points
 from hipscat.loaders import read_from_hipscat
 
+# pylint: disable=no-member
 
-@pytest.mark.parametrize("projection", ["moll", "gnom", "cart", "orth"])
-def test_generate_map(small_sky_dir, projection):
-    """Basic test that map data can be generated (does not test that a plot is rendered)"""
+
+def test_generate_projections(small_sky_dir, mocker):
+    """Basic test that map data can be generated"""
 
     cat = read_from_hipscat(small_sky_dir)
-    plot_pixels(cat, projection=projection, draw_map=False)
-    plot_points(cat, projection=projection, draw_map=False)
+
+    projection = "moll"
+    mocker.patch("healpy.mollview")
+    plot_pixels(cat, projection=projection)
+    hp.mollview.assert_called_once()
+    hp.mollview.reset_mock()
+    plot_points(cat, projection=projection)
+    hp.mollview.assert_called_once()
+
+    projection = "gnom"
+    mocker.patch("healpy.gnomview")
+    plot_pixels(cat, projection=projection)
+    hp.gnomview.assert_called_once()
+    hp.gnomview.reset_mock()
+    plot_points(cat, projection=projection)
+    hp.gnomview.assert_called_once()
+
+    projection = "cart"
+    mocker.patch("healpy.cartview")
+    plot_pixels(cat, projection=projection)
+    hp.cartview.assert_called_once()
+    hp.cartview.reset_mock()
+    plot_points(cat, projection=projection)
+    hp.cartview.assert_called_once()
+
+    projection = "orth"
+    mocker.patch("healpy.orthview")
+    plot_pixels(cat, projection=projection)
+    hp.orthview.assert_called_once()
+    hp.orthview.reset_mock()
+    plot_points(cat, projection=projection)
+    hp.orthview.assert_called_once()
 
 
 def test_generate_map_unknown_projection(small_sky_dir):
@@ -19,28 +51,41 @@ def test_generate_map_unknown_projection(small_sky_dir):
 
     cat = read_from_hipscat(small_sky_dir)
     with pytest.raises(NotImplementedError):
-        plot_pixels(cat, projection=None, draw_map=False)
+        plot_pixels(cat, projection=None)
 
     with pytest.raises(NotImplementedError):
-        plot_pixels(cat, projection="", draw_map=False)
+        plot_pixels(cat, projection="")
 
     with pytest.raises(NotImplementedError):
-        plot_pixels(cat, projection="projection", draw_map=False)
+        plot_pixels(cat, projection="projection")
 
 
-def test_generate_map_order1(small_sky_order1_dir):
-    """Basic test that map data can be generated (does not test that a plot is rendered)"""
+def test_plot_pixel_map_order1(small_sky_order1_dir, mocker):
+    """Basic test that map data can be generated"""
+    mocker.patch("healpy.mollview")
 
     cat = read_from_hipscat(small_sky_order1_dir)
-    plot_pixels(cat, draw_map=False)
-    plot_points(cat, draw_map=False)
+    plot_pixels(cat)
+    hp.mollview.assert_called_once()
+
+    hp.mollview.reset_mock()
+
+    plot_points(cat)
+    hp.mollview.assert_called_once()
 
 
-def test_visualize_in_memory_catalogs(catalog_info, catalog_pixels):
+def test_visualize_in_memory_catalogs(catalog_info, catalog_pixels, mocker):
     """Test behavior of visualization methods for non-on-disk catalogs and pixel data."""
+    mocker.patch("healpy.mollview")
     catalog = Catalog(catalog_info, catalog_pixels)
-    plot_pixels(catalog, draw_map=False)
-    plot_pixel_list(catalog_pixels, plot_title="My special catalog", draw_map=False)
+    plot_pixels(catalog)
+    hp.mollview.assert_called_once()
 
+    hp.mollview.reset_mock()
+    plot_pixel_list(catalog_pixels, plot_title="My special catalog")
+    hp.mollview.assert_called_once()
+
+    hp.mollview.reset_mock()
     with pytest.raises(ValueError, match="on disk catalog required"):
-        plot_points(catalog, draw_map=False)
+        plot_points(catalog)
+    hp.mollview.assert_not_called()


### PR DESCRIPTION
## Change Description

Related to issue #227 .

## Solution Description

- Use mock for healpy plotting method.
- Always draw the map (can be safely done with mock).
- Add kwargs to methods, so users can pass along their own healpy/matplotlib preferences.