### PR TITLE
Fix base catalog info types

### DIFF
--- a/src/hipscat/catalog/dataset/base_catalog_info.py
+++ b/src/hipscat/catalog/dataset/base_catalog_info.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 from dataclasses import dataclass
 from typing import Any, Dict, Union
@@ -13,8 +15,8 @@ class BaseCatalogInfo:
     """Container class for catalog metadata"""
 
     catalog_name: str = ""
-    catalog_type: CatalogType = None
-    total_rows: int = None
+    catalog_type: CatalogType | None = None
+    total_rows: int | None = None
 
     DEFAULT_TYPE = None
     """The default catalog type for this catalog info type. To be overridden by subclasses.


### PR DESCRIPTION
When loading a catalog subset ([LSDB PR#231](https://github.com/astronomy-commons/lsdb/pull/231)) we do not want the catalog info to have an incorrect number of `total_rows` so we set it to None. This variable is already None by default but its typing is wrong; same goes for `catalog_type`. For reference, the mypy [check](https://github.com/astronomy-commons/lsdb/actions/runs/8254608738/job/22579146306?pr=231#step:5:320) on LSDB failed with: 

`src/lsdb/loaders/hipscat/abstract_catalog_loader.py:54: error: Argument "total_rows" to "replace" of "BaseCatalogInfo" has incompatible type "None"; expected "int"  [arg-type]`.

- [ ] My PR includes a link to the issue that I am addressing
