### PR TITLE
Add fsspec http extra dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
     "astropy",
-    "fsspec<=2023.9.2", # Used for abstract filesystems
+    "fsspec[http]<=2023.9.2", # Used for abstract filesystems
     "healpy",
     "numba>=0.58",
     "numpy", 


### PR DESCRIPTION
When attempting to load a notebook via HTTPS I detected that fsspec requires "aiohttp" to properly work. This dependency is defined in their "http" extras, as documented [here](https://github.com/fsspec/filesystem_spec/issues/427), and therefore we should include it in the package requirements.

- [ ] My PR includes a link to the issue that I am addressing

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation