### PR TITLE
Add storage options to more catalog calls

### DIFF
--- a/src/hipscat/catalog/index/index_catalog.py
+++ b/src/hipscat/catalog/index/index_catalog.py
@@ -8,6 +8,7 @@ from typing_extensions import TypeAlias
 from hipscat.catalog.dataset import Dataset
 from hipscat.catalog.index import IndexCatalogInfo
 from hipscat.io import paths
+from hipscat.io.file_io.file_pointer import get_fs, strip_leading_slash_for_pyarrow
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.healpix_pixel_function import get_pixel_argsort
 
@@ -31,7 +32,12 @@ class IndexCatalog(Dataset):
             that may contain rows for the id values
         """
         metadata_file = paths.get_parquet_metadata_pointer(self.catalog_base_dir)
-        dataset = pds.parquet_dataset(metadata_file)
+        file_system, metadata_file = get_fs(file_pointer=metadata_file, storage_options=self.storage_options)
+
+        # pyarrow.dataset requires the pointer not lead with a slash
+        metadata_file = strip_leading_slash_for_pyarrow(metadata_file, file_system.protocol)
+
+        dataset = pds.parquet_dataset(metadata_file, filesystem=file_system)
 
         # There's a lot happening in a few pyarrow dataset methods:
         # We create a simple pyarrow expression that roughly corresponds to a SQL statement like

--- a/src/hipscat/io/validation.py
+++ b/src/hipscat/io/validation.py
@@ -1,26 +1,33 @@
+from typing import Any, Dict, Union
+
 from hipscat.catalog.dataset.catalog_info_factory import from_catalog_dir
 from hipscat.io import get_parquet_metadata_pointer, get_partition_info_pointer
 from hipscat.io.file_io.file_pointer import FilePointer, is_regular_file
 
 
-def is_valid_catalog(pointer: FilePointer) -> bool:
+def is_valid_catalog(pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None) -> bool:
     """Checks if a catalog is valid for a given base catalog pointer
 
     Args:
         pointer (FilePointer): pointer to base catalog directory
+        storage_options: dictionary that contains abstract filesystem credentials
 
     Returns:
         True if both the catalog_info and partition_info files are
         valid, False otherwise
     """
-    return is_catalog_info_valid(pointer) and (is_partition_info_valid(pointer) or is_metadata_valid(pointer))
+    return is_catalog_info_valid(pointer, storage_options=storage_options) and (
+        is_partition_info_valid(pointer, storage_options=storage_options)
+        or is_metadata_valid(pointer, storage_options=storage_options)
+    )
 
 
-def is_catalog_info_valid(pointer: FilePointer) -> bool:
+def is_catalog_info_valid(pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None) -> bool:
     """Checks if catalog_info is valid for a given base catalog pointer
 
     Args:
         pointer (FilePointer): pointer to base catalog directory
+        storage_options: dictionary that contains abstract filesystem credentials
 
     Returns:
         True if the catalog_info file exists, and it is correctly formatted,
@@ -28,35 +35,39 @@ def is_catalog_info_valid(pointer: FilePointer) -> bool:
     """
     is_valid = True
     try:
-        from_catalog_dir(pointer)
+        from_catalog_dir(pointer, storage_options=storage_options)
     except (FileNotFoundError, ValueError, NotImplementedError):
         is_valid = False
     return is_valid
 
 
-def is_partition_info_valid(pointer: FilePointer) -> bool:
+def is_partition_info_valid(
+    pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
+) -> bool:
     """Checks if partition_info is valid for a given base catalog pointer
 
     Args:
         pointer (FilePointer): pointer to base catalog directory
+        storage_options: dictionary that contains abstract filesystem credentials
 
     Returns:
         True if the partition_info file exists, False otherwise
     """
     partition_info_pointer = get_partition_info_pointer(pointer)
-    partition_info_exists = is_regular_file(partition_info_pointer)
+    partition_info_exists = is_regular_file(partition_info_pointer, storage_options=storage_options)
     return partition_info_exists
 
 
-def is_metadata_valid(pointer: FilePointer) -> bool:
+def is_metadata_valid(pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None) -> bool:
     """Checks if _metadata is valid for a given base catalog pointer
 
     Args:
         pointer (FilePointer): pointer to base catalog directory
+        storage_options: dictionary that contains abstract filesystem credentials
 
     Returns:
         True if the _metadata file exists, False otherwise
     """
     metadata_file = get_parquet_metadata_pointer(pointer)
-    metadata_file_exists = is_regular_file(metadata_file)
+    metadata_file_exists = is_regular_file(metadata_file, storage_options=storage_options)
     return metadata_file_exists

--- a/src/hipscat/loaders/read_from_hipscat.py
+++ b/src/hipscat/loaders/read_from_hipscat.py
@@ -41,7 +41,7 @@ def read_from_hipscat(
         else catalog_type
     )
     loader = _get_loader_from_catalog_type(catalog_type_to_use)
-    return loader.read_from_hipscat(catalog_path)
+    return loader.read_from_hipscat(catalog_path, storage_options=storage_options)
 
 
 def _read_dataset_class_from_metadata(


### PR DESCRIPTION
## Change Description

Closes #240 

Related to astronomy-commons/lsdb#103

## Solution Description

Optionally passes along a `storage_options` dictionary. 

Also, addresses issues with direct read of parquet datasets from remote storage.