### PR TITLE
Prepend file protocol to pointer

### DIFF
--- a/src/hipscat/io/file_io/file_pointer.py
+++ b/src/hipscat/io/file_io/file_pointer.py
@@ -80,10 +80,12 @@ def get_file_pointer_for_fs(protocol: str, file_pointer: FilePointer) -> FilePoi
     return FilePointer(split_pointer)
 
 
-def get_full_file_pointer(incomplete_path: str, protocol_path: str) -> FilePointer:
+def get_full_file_pointer(path: str, protocol_path: str) -> FilePointer:
     """Rebuilds the file_pointer with the protocol and account name if required"""
     protocol = get_file_protocol(protocol_path)
-    return FilePointer(f"{protocol}://{incomplete_path}")
+    if not path.startswith(protocol):
+        path = f"{protocol}://{path}"
+    return FilePointer(path)
 
 
 def get_file_pointer_from_path(path: str, include_protocol: str = None) -> FilePointer:


### PR DESCRIPTION
Checks if a file path is complete (i.e. it is prefixed by the correct protocol) and prepends it if not.

- [ ] My PR includes a link to the issue that I am addressing

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation