### PR TITLE
Add paths method for getting multiple paths

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -12,6 +12,7 @@ import hipscat.pixel_math as hist
 from hipscat.catalog import Catalog, PartitionInfo
 from hipscat.catalog.association_catalog.partition_join_info import PartitionJoinInfo
 from hipscat.catalog.catalog_info import CatalogInfo
+from hipscat.io.paths import pixel_catalog_files
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_tree import PixelAlignment, align_trees
 from hipscat.pixel_tree.pixel_tree_builder import PixelTreeBuilder
@@ -54,6 +55,9 @@ class Suite:
 
     def time_pixel_tree_creation(self):
         PixelTreeBuilder.from_healpix(self.pixel_list)
+
+    def time_paths_creation(self):
+        pixel_catalog_files("foo/", self.pixel_list)
 
 
 class MetadataSuite:

--- a/src/hipscat/io/paths.py
+++ b/src/hipscat/io/paths.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import re
+from typing import List, Dict
 
-from hipscat.io.file_io.file_pointer import FilePointer, append_paths_to_pointer
+from hipscat.io.file_io.file_pointer import FilePointer, append_paths_to_pointer, get_fs
 from hipscat.pixel_math.healpix_pixel import INVALID_PIXEL, HealpixPixel
 
 ORDER_DIRECTORY_PREFIX = "Norder"
@@ -83,6 +84,16 @@ def get_healpix_from_path(path: str) -> HealpixPixel:
         return INVALID_PIXEL
     order, pixel = match.groups()
     return HealpixPixel(int(order), int(pixel))
+
+
+def pixel_catalog_files(catalog_base_dir: FilePointer, pixels: List[HealpixPixel], storage_options: Dict):
+    fs, _ = get_fs(catalog_base_dir, storage_options)
+    base_path_stripped = catalog_base_dir.removesuffix(fs.sep)
+    return [fs.sep.join([base_path_stripped,
+                         f"{ORDER_DIRECTORY_PREFIX}={pixel.order}",
+                         f"{DIR_DIRECTORY_PREFIX}={pixel.pixel // 10000 * 10000}",
+                         f"{PIXEL_DIRECTORY_PREFIX}={pixel.pixel}.parquet"
+                         ]) for pixel in pixels]
 
 
 def pixel_catalog_file(catalog_base_dir: FilePointer, pixel_order: int, pixel_number: int) -> FilePointer:

--- a/src/hipscat/io/paths.py
+++ b/src/hipscat/io/paths.py
@@ -86,7 +86,11 @@ def get_healpix_from_path(path: str) -> HealpixPixel:
     return HealpixPixel(int(order), int(pixel))
 
 
-def pixel_catalog_files(catalog_base_dir: FilePointer, pixels: List[HealpixPixel], storage_options: Dict):
+def pixel_catalog_files(
+        catalog_base_dir: FilePointer,
+        pixels: List[HealpixPixel],
+        storage_options: Dict | None = None
+):
     fs, _ = get_fs(catalog_base_dir, storage_options)
     base_path_stripped = catalog_base_dir.removesuffix(fs.sep)
     return [fs.sep.join([base_path_stripped,

--- a/src/hipscat/io/paths.py
+++ b/src/hipscat/io/paths.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import List, Dict
+from typing import Dict, List
 
 from hipscat.io.file_io.file_pointer import FilePointer, append_paths_to_pointer, get_fs
 from hipscat.pixel_math.healpix_pixel import INVALID_PIXEL, HealpixPixel
@@ -87,17 +87,39 @@ def get_healpix_from_path(path: str) -> HealpixPixel:
 
 
 def pixel_catalog_files(
-        catalog_base_dir: FilePointer,
-        pixels: List[HealpixPixel],
-        storage_options: Dict | None = None
-):
+    catalog_base_dir: FilePointer, pixels: List[HealpixPixel], storage_options: Dict | None = None
+) -> List[FilePointer]:
+    """Create a list of path *pointers* for pixel catalog files. This will not create the directory
+    or files.
+
+    The catalog file names will take the HiPS standard form of::
+
+        <catalog_base_dir>/Norder=<pixel_order>/Dir=<directory number>/Npix=<pixel_number>.parquet
+
+    Where the directory number is calculated using integer division as::
+
+        (pixel_number/10000)*10000
+
+    Args:
+        catalog_base_dir (FilePointer): base directory of the catalog (includes catalog name)
+        pixels (List[HealpixPixel]): the healpix pixels to create pointers to
+        storage_options (dict): the storage options for the file system to target when generating the paths
+    Returns (List[FilePointer]):
+        A list of paths to the pixels, in the same order as the input pixel list.
+    """
     fs, _ = get_fs(catalog_base_dir, storage_options)
     base_path_stripped = catalog_base_dir.removesuffix(fs.sep)
-    return [fs.sep.join([base_path_stripped,
-                         f"{ORDER_DIRECTORY_PREFIX}={pixel.order}",
-                         f"{DIR_DIRECTORY_PREFIX}={pixel.dir}",
-                         f"{PIXEL_DIRECTORY_PREFIX}={pixel.pixel}.parquet"
-                         ]) for pixel in pixels]
+    return [
+        fs.sep.join(
+            [
+                base_path_stripped,
+                f"{ORDER_DIRECTORY_PREFIX}={pixel.order}",
+                f"{DIR_DIRECTORY_PREFIX}={pixel.dir}",
+                f"{PIXEL_DIRECTORY_PREFIX}={pixel.pixel}.parquet",
+            ]
+        )
+        for pixel in pixels
+    ]
 
 
 def pixel_catalog_file(catalog_base_dir: FilePointer, pixel_order: int, pixel_number: int) -> FilePointer:

--- a/src/hipscat/io/paths.py
+++ b/src/hipscat/io/paths.py
@@ -95,7 +95,7 @@ def pixel_catalog_files(
     base_path_stripped = catalog_base_dir.removesuffix(fs.sep)
     return [fs.sep.join([base_path_stripped,
                          f"{ORDER_DIRECTORY_PREFIX}={pixel.order}",
-                         f"{DIR_DIRECTORY_PREFIX}={pixel.pixel // 10000 * 10000}",
+                         f"{DIR_DIRECTORY_PREFIX}={pixel.dir}",
                          f"{PIXEL_DIRECTORY_PREFIX}={pixel.pixel}.parquet"
                          ]) for pixel in pixels]
 

--- a/tests/hipscat/io/test_paths.py
+++ b/tests/hipscat/io/test_paths.py
@@ -48,6 +48,12 @@ def test_pixel_catalog_file_nonint():
         paths.pixel_catalog_file("/foo", "zero", "five")
 
 
+def test_pixel_catalog_files():
+    expected = ["/foo/Norder=0/Dir=0/Npix=5.parquet", "/foo/Norder=1/Dir=0/Npix=16.parquet"]
+    result = paths.pixel_catalog_files("/foo", [HealpixPixel(0, 5), HealpixPixel(1, 16)])
+    assert expected == result
+
+
 def test_get_healpix_from_path():
     expected = HealpixPixel(5, 34)
 


### PR DESCRIPTION
Looping through `pixel_catalog_file` can be inefficient, so add `pixel_catalog_files` method which generates multiple paths.