### PR TITLE
Optimize Inner PixelTree Alignment

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -66,7 +66,7 @@ class Suite:
         align_trees(self.pixel_tree_1, self.pixel_tree_2)
 
     def time_outer_pixel_alignment(self):
-        align_trees(self.pixel_tree_1, self.pixel_tree_2, alignment_type='outer')
+        align_trees(self.pixel_tree_1, self.pixel_tree_2, alignment_type="outer")
 
     def time_paths_creation(self):
         pixel_catalog_files("foo/", self.pixel_list)

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -49,12 +49,24 @@ class Suite:
     def __init__(self) -> None:
         """Just initialize things"""
         self.pixel_list = None
+        self.pixel_tree_1 = None
+        self.pixel_tree_2 = None
 
     def setup(self):
         self.pixel_list = [HealpixPixel(8, pixel) for pixel in np.arange(100000)]
+        self.pixel_tree_1 = PixelTreeBuilder.from_healpix(self.pixel_list)
+        self.pixel_tree_2 = PixelTreeBuilder.from_healpix(
+            [HealpixPixel(9, pixel) for pixel in np.arange(0, 400000, 4)]
+        )
 
     def time_pixel_tree_creation(self):
         PixelTreeBuilder.from_healpix(self.pixel_list)
+
+    def time_inner_pixel_alignment(self):
+        align_trees(self.pixel_tree_1, self.pixel_tree_2)
+
+    def time_outer_pixel_alignment(self):
+        align_trees(self.pixel_tree_1, self.pixel_tree_2, alignment_type='outer')
 
     def time_paths_creation(self):
         pixel_catalog_files("foo/", self.pixel_list)

--- a/src/hipscat/pixel_tree/pixel_alignment.py
+++ b/src/hipscat/pixel_tree/pixel_alignment.py
@@ -192,7 +192,11 @@ def perform_inner_align_trees(
             left_index += 1
             continue
         # else overlapping and right smaller so add right and move right on
-        mapping[out_index][0:2], mapping[out_index][2:4], mapping[out_index][4:6] = (left_pix, right_pix, right_pix)
+        mapping[out_index][0:2], mapping[out_index][2:4], mapping[out_index][4:6] = (
+            left_pix,
+            right_pix,
+            right_pix,
+        )
         out_index += 1
         right_index += 1
     return mapping[:out_index].T

--- a/src/hipscat/pixel_tree/pixel_alignment.py
+++ b/src/hipscat/pixel_tree/pixel_alignment.py
@@ -156,7 +156,7 @@ def perform_inner_align_trees(
     mapping = np.zeros((max_out_len, 6), dtype=np.int64)
     left_index = 0
     right_index = 0
-    out_len = 0
+    last_index = 0
     while left_index < len(left) and right_index < len(right):
         left_pix = left[left_index]
         right_pix = right[right_index]
@@ -172,30 +172,30 @@ def perform_inner_align_trees(
         right_size = right_pix[1] - right_pix[0]
         if left_size == right_size:
             # overlapping & same size => same pixel so add and move both on
-            mapping[out_len][0:2], mapping[out_len][2:4], mapping[out_len][4:6] = (
+            mapping[last_index][0:2], mapping[last_index][2:4], mapping[last_index][4:6] = (
                 left_pix,
                 right_pix,
                 left_pix,
             )
-            out_len += 1
+            last_index += 1
             left_index += 1
             right_index += 1
             continue
         if left_size < right_size:
             # overlapping and left smaller so add left and move left on
-            mapping[out_len][0:2], mapping[out_len][2:4], mapping[out_len][4:6] = (
+            mapping[last_index][0:2], mapping[last_index][2:4], mapping[last_index][4:6] = (
                 left_pix,
                 right_pix,
                 left_pix,
             )
-            out_len += 1
+            last_index += 1
             left_index += 1
             continue
         # else overlapping and right smaller so add right and move right on
-        mapping[out_len][0:2], mapping[out_len][2:4], mapping[out_len][4:6] = (left_pix, right_pix, right_pix)
-        out_len += 1
+        mapping[last_index][0:2], mapping[last_index][2:4], mapping[last_index][4:6] = (left_pix, right_pix, right_pix)
+        last_index += 1
         right_index += 1
-    return mapping[:out_len].T
+    return mapping[:last_index].T
 
 
 @njit(

--- a/src/hipscat/pixel_tree/pixel_alignment.py
+++ b/src/hipscat/pixel_tree/pixel_alignment.py
@@ -156,7 +156,7 @@ def perform_inner_align_trees(
     mapping = np.zeros((max_out_len, 6), dtype=np.int64)
     left_index = 0
     right_index = 0
-    last_index = 0
+    out_index = 0
     while left_index < len(left) and right_index < len(right):
         left_pix = left[left_index]
         right_pix = right[right_index]
@@ -172,30 +172,30 @@ def perform_inner_align_trees(
         right_size = right_pix[1] - right_pix[0]
         if left_size == right_size:
             # overlapping & same size => same pixel so add and move both on
-            mapping[last_index][0:2], mapping[last_index][2:4], mapping[last_index][4:6] = (
+            mapping[out_index][0:2], mapping[out_index][2:4], mapping[out_index][4:6] = (
                 left_pix,
                 right_pix,
                 left_pix,
             )
-            last_index += 1
+            out_index += 1
             left_index += 1
             right_index += 1
             continue
         if left_size < right_size:
             # overlapping and left smaller so add left and move left on
-            mapping[last_index][0:2], mapping[last_index][2:4], mapping[last_index][4:6] = (
+            mapping[out_index][0:2], mapping[out_index][2:4], mapping[out_index][4:6] = (
                 left_pix,
                 right_pix,
                 left_pix,
             )
-            last_index += 1
+            out_index += 1
             left_index += 1
             continue
         # else overlapping and right smaller so add right and move right on
-        mapping[last_index][0:2], mapping[last_index][2:4], mapping[last_index][4:6] = (left_pix, right_pix, right_pix)
-        last_index += 1
+        mapping[out_index][0:2], mapping[out_index][2:4], mapping[out_index][4:6] = (left_pix, right_pix, right_pix)
+        out_index += 1
         right_index += 1
-    return mapping[:last_index].T
+    return mapping[:out_index].T
 
 
 @njit(

--- a/src/hipscat/pixel_tree/pixel_alignment.py
+++ b/src/hipscat/pixel_tree/pixel_alignment.py
@@ -172,14 +172,22 @@ def perform_inner_align_trees(
         right_size = right_pix[1] - right_pix[0]
         if left_size == right_size:
             # overlapping & same size => same pixel so add and move both on
-            mapping[out_len][0:2], mapping[out_len][2:4], mapping[out_len][4:6] = (left_pix, right_pix, left_pix)
+            mapping[out_len][0:2], mapping[out_len][2:4], mapping[out_len][4:6] = (
+                left_pix,
+                right_pix,
+                left_pix,
+            )
             out_len += 1
             left_index += 1
             right_index += 1
             continue
         if left_size < right_size:
             # overlapping and left smaller so add left and move left on
-            mapping[out_len][0:2], mapping[out_len][2:4], mapping[out_len][4:6] = (left_pix, right_pix, left_pix)
+            mapping[out_len][0:2], mapping[out_len][2:4], mapping[out_len][4:6] = (
+                left_pix,
+                right_pix,
+                left_pix,
+            )
             out_len += 1
             left_index += 1
             continue


### PR DESCRIPTION
When performing inner pixel tree alignments, we can bound the maximum number of aligned pixels, meaning we can make inner alignments more performant by using an array of the maximum length instead of appending to a list.

Adds benchmarks for pixel tree alignment.