### PR TITLE
Add moc as a parameter to HealpixDataset and subclasses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "astropy",
     "fsspec<=2023.9.2", # Used for abstract filesystems
     "healpy",
+    "mocpy",
     "numba>=0.58",
     "numpy", 
     "pandas",

--- a/src/hipscat/catalog/association_catalog/association_catalog.py
+++ b/src/hipscat/catalog/association_catalog/association_catalog.py
@@ -39,7 +39,7 @@ class AssociationCatalog(HealpixDataset):
     ) -> None:
         if not catalog_info.catalog_type == CatalogType.ASSOCIATION:
             raise ValueError("Catalog info `catalog_type` must be 'association'")
-        super().__init__(catalog_info, pixels, catalog_path, storage_options=storage_options, moc=moc)
+        super().__init__(catalog_info, pixels, catalog_path, moc=moc, storage_options=storage_options)
         self.join_info = self._get_partition_join_info_from_pixels(join_pixels)
 
     def get_join_pixels(self) -> pd.DataFrame:

--- a/src/hipscat/catalog/association_catalog/association_catalog.py
+++ b/src/hipscat/catalog/association_catalog/association_catalog.py
@@ -34,8 +34,8 @@ class AssociationCatalog(HealpixDataset):
         pixels: PixelInputTypes,
         join_pixels: JoinPixelInputTypes,
         catalog_path=None,
-        storage_options: Union[Dict[Any, Any], None] = None,
         moc: MOC | None = None,
+        storage_options: Union[Dict[Any, Any], None] = None,
     ) -> None:
         if not catalog_info.catalog_type == CatalogType.ASSOCIATION:
             raise ValueError("Catalog info `catalog_type` must be 'association'")

--- a/src/hipscat/catalog/association_catalog/association_catalog.py
+++ b/src/hipscat/catalog/association_catalog/association_catalog.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Dict, Tuple, Union
 
 import pandas as pd

--- a/src/hipscat/catalog/association_catalog/association_catalog.py
+++ b/src/hipscat/catalog/association_catalog/association_catalog.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Tuple, Union
 
 import pandas as pd
+from mocpy import MOC
 from typing_extensions import TypeAlias
 
 from hipscat.catalog.association_catalog.association_catalog_info import AssociationCatalogInfo
@@ -32,10 +33,11 @@ class AssociationCatalog(HealpixDataset):
         join_pixels: JoinPixelInputTypes,
         catalog_path=None,
         storage_options: Union[Dict[Any, Any], None] = None,
+        moc: MOC | None = None,
     ) -> None:
         if not catalog_info.catalog_type == CatalogType.ASSOCIATION:
             raise ValueError("Catalog info `catalog_type` must be 'association'")
-        super().__init__(catalog_info, pixels, catalog_path, storage_options=storage_options)
+        super().__init__(catalog_info, pixels, catalog_path, storage_options=storage_options, moc=moc)
         self.join_info = self._get_partition_join_info_from_pixels(join_pixels)
 
     def get_join_pixels(self) -> pd.DataFrame:

--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Tuple, Union
 
 import healpy as hp
 import numpy as np
+from mocpy import MOC
 from typing_extensions import TypeAlias
 
 from hipscat.catalog.catalog_info import CatalogInfo
@@ -49,6 +50,7 @@ class Catalog(HealpixDataset):
         pixels: PixelInputTypes,
         catalog_path: str = None,
         storage_options: Union[Dict[Any, Any], None] = None,
+        moc: MOC | None = None,
     ) -> None:
         """Initializes a Catalog
 
@@ -59,13 +61,14 @@ class Catalog(HealpixDataset):
             catalog_path: If the catalog is stored on disk, specify the location of the catalog
                 Does not load the catalog from this path, only store as metadata
             storage_options: dictionary that contains abstract filesystem credentials
+            moc (mocpy.MOC): MOC object representing the coverage of the catalog
         """
         if catalog_info.catalog_type not in self.HIPS_CATALOG_TYPES:
             raise ValueError(
                 f"Catalog info `catalog_type` must be one of "
                 f"{', '.join([t.value for t in self.HIPS_CATALOG_TYPES])}"
             )
-        super().__init__(catalog_info, pixels, catalog_path, storage_options)
+        super().__init__(catalog_info, pixels, catalog_path, storage_options, moc)
 
     def filter_by_cone(self, ra: float, dec: float, radius_arcsec: float) -> Catalog:
         """Filter the pixels in the catalog to only include the pixels that overlap with a cone

--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -69,7 +69,7 @@ class Catalog(HealpixDataset):
                 f"{', '.join([t.value for t in self.HIPS_CATALOG_TYPES])}"
             )
         super().__init__(
-            catalog_info, pixels, catalog_path=catalog_path, storage_options=storage_options, moc=moc
+            catalog_info, pixels, catalog_path=catalog_path, moc=moc, storage_options=storage_options
         )
 
     def filter_by_cone(self, ra: float, dec: float, radius_arcsec: float) -> Catalog:

--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -49,8 +49,8 @@ class Catalog(HealpixDataset):
         catalog_info: CatalogInfoClass,
         pixels: PixelInputTypes,
         catalog_path: str = None,
-        storage_options: Union[Dict[Any, Any], None] = None,
         moc: MOC | None = None,
+        storage_options: Union[Dict[Any, Any], None] = None,
     ) -> None:
         """Initializes a Catalog
 
@@ -68,7 +68,9 @@ class Catalog(HealpixDataset):
                 f"Catalog info `catalog_type` must be one of "
                 f"{', '.join([t.value for t in self.HIPS_CATALOG_TYPES])}"
             )
-        super().__init__(catalog_info, pixels, catalog_path, storage_options, moc)
+        super().__init__(
+            catalog_info, pixels, catalog_path=catalog_path, storage_options=storage_options, moc=moc
+        )
 
     def filter_by_cone(self, ra: float, dec: float, radius_arcsec: float) -> Catalog:
         """Filter the pixels in the catalog to only include the pixels that overlap with a cone

--- a/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
@@ -105,6 +105,7 @@ class HealpixDataset(Dataset):
     def _read_moc_from_point_map(
         cls, catalog_base_dir: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
     ) -> MOC | None:
+        """Reads a MOC object from the `point_map.fits` file if it exists in the catalog directory"""
         point_map_path = paths.get_point_map_file_pointer(catalog_base_dir)
         if not file_io.does_file_or_directory_exist(point_map_path, storage_options=storage_options):
             return None

--- a/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 from typing import Any, Dict, List, Tuple, Union
 
@@ -101,7 +103,7 @@ class HealpixDataset(Dataset):
 
     @classmethod
     def _read_moc_from_point_map(
-            cls, catalog_base_dir: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
+        cls, catalog_base_dir: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
     ) -> MOC | None:
         point_map_path = paths.get_point_map_file_pointer(catalog_base_dir)
         if not file_io.does_file_or_directory_exist(point_map_path, storage_options=storage_options):

--- a/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
@@ -36,8 +36,8 @@ class HealpixDataset(Dataset):
         catalog_info: CatalogInfoClass,
         pixels: PixelInputTypes,
         catalog_path: str = None,
-        storage_options: Union[Dict[Any, Any], None] = None,
         moc: MOC | None = None,
+        storage_options: Union[Dict[Any, Any], None] = None,
     ) -> None:
         """Initializes a Catalog
 
@@ -50,7 +50,7 @@ class HealpixDataset(Dataset):
             storage_options: dictionary that contains abstract filesystem credentials
             moc (mocpy.MOC): MOC object representing the coverage of the catalog
         """
-        super().__init__(catalog_info, catalog_path, storage_options)
+        super().__init__(catalog_info, catalog_path=catalog_path, storage_options=storage_options)
         self.partition_info = self._get_partition_info_from_pixels(pixels)
         self.pixel_tree = self._get_pixel_tree_from_pixels(pixels)
         self.moc = moc

--- a/src/hipscat/catalog/margin_cache/margin_catalog.py
+++ b/src/hipscat/catalog/margin_cache/margin_catalog.py
@@ -44,5 +44,5 @@ class MarginCatalog(HealpixDataset):
         if catalog_info.catalog_type != CatalogType.MARGIN:
             raise ValueError(f"Catalog info `catalog_type` must equal {CatalogType.MARGIN}")
         super().__init__(
-            catalog_info, pixels, catalog_path=catalog_path, storage_options=storage_options, moc=moc
+            catalog_info, pixels, catalog_path=catalog_path, moc=moc, storage_options=storage_options
         )

--- a/src/hipscat/catalog/margin_cache/margin_catalog.py
+++ b/src/hipscat/catalog/margin_cache/margin_catalog.py
@@ -27,8 +27,8 @@ class MarginCatalog(HealpixDataset):
         catalog_info: CatalogInfoClass,
         pixels: PixelInputTypes,
         catalog_path: str = None,
-        storage_options: dict | None = None,
         moc: MOC | None = None,
+        storage_options: dict | None = None,
     ) -> None:
         """Initializes a Margin Catalog
 
@@ -43,4 +43,6 @@ class MarginCatalog(HealpixDataset):
         """
         if catalog_info.catalog_type != CatalogType.MARGIN:
             raise ValueError(f"Catalog info `catalog_type` must equal {CatalogType.MARGIN}")
-        super().__init__(catalog_info, pixels, catalog_path, storage_options, moc)
+        super().__init__(
+            catalog_info, pixels, catalog_path=catalog_path, storage_options=storage_options, moc=moc
+        )

--- a/src/hipscat/catalog/margin_cache/margin_catalog.py
+++ b/src/hipscat/catalog/margin_cache/margin_catalog.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from mocpy import MOC
 from typing_extensions import TypeAlias
 
 from hipscat.catalog.catalog_type import CatalogType
@@ -27,6 +28,7 @@ class MarginCatalog(HealpixDataset):
         pixels: PixelInputTypes,
         catalog_path: str = None,
         storage_options: dict | None = None,
+        moc: MOC | None = None,
     ) -> None:
         """Initializes a Margin Catalog
 
@@ -37,7 +39,8 @@ class MarginCatalog(HealpixDataset):
             catalog_path: If the catalog is stored on disk, specify the location of the catalog
                 Does not load the catalog from this path, only store as metadata
             storage_options: dictionary that contains abstract filesystem credentials
+            moc (mocpy.MOC): MOC object representing the coverage of the catalog
         """
         if catalog_info.catalog_type != CatalogType.MARGIN:
             raise ValueError(f"Catalog info `catalog_type` must equal {CatalogType.MARGIN}")
-        super().__init__(catalog_info, pixels, catalog_path, storage_options)
+        super().__init__(catalog_info, pixels, catalog_path, storage_options, moc)

--- a/tests/hipscat/catalog/test_catalog.py
+++ b/tests/hipscat/catalog/test_catalog.py
@@ -7,6 +7,8 @@ import numpy as np
 import pytest
 
 from hipscat.catalog import Catalog, CatalogType, PartitionInfo
+from hipscat.io import paths
+from hipscat.io.file_io import read_fits_image
 from hipscat.loaders import read_from_hipscat
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.box_filter import _generate_ra_strip_pixel_tree
@@ -92,6 +94,17 @@ def test_load_catalog_small_sky_order1(small_sky_order1_dir):
     assert cat.catalog_name == "small_sky_order1"
     assert len(cat.get_healpix_pixels()) == 4
 
+
+def test_load_catalog_small_sky_order1_moc(small_sky_order1_dir):
+    """Instantiate a catalog with 4 pixels"""
+    cat = read_from_hipscat(small_sky_order1_dir)
+
+    assert isinstance(cat, Catalog)
+    assert cat.moc is not None
+    counts_skymap = read_fits_image(paths.get_point_map_file_pointer(small_sky_order1_dir))
+    skymap_order = hp.nside2order(hp.npix2nside(len(counts_skymap)))
+    assert cat.moc.max_order == skymap_order
+    assert np.all(cat.moc.flatten() == np.where(counts_skymap > 0))
 
 def test_load_catalog_small_sky_source(small_sky_source_dir):
     """Instantiate a source catalog with 14 pixels"""

--- a/tests/hipscat/catalog/test_catalog.py
+++ b/tests/hipscat/catalog/test_catalog.py
@@ -106,6 +106,7 @@ def test_load_catalog_small_sky_order1_moc(small_sky_order1_dir):
     assert cat.moc.max_order == skymap_order
     assert np.all(cat.moc.flatten() == np.where(counts_skymap > 0))
 
+
 def test_load_catalog_small_sky_source(small_sky_source_dir):
     """Instantiate a source catalog with 14 pixels"""
     cat = read_from_hipscat(small_sky_source_dir)


### PR DESCRIPTION
Adds the `moc` optional parameter to the `HealpixDataset` class. This enables keeping track of and using the coverage of a catalog at a higher order than the partition pixels, which will allow us to do more efficient alignments for joins and crossmatches in LSDB.

Adds loading the MOC from the `point_map.fits` file if it exists when a catalog is loaded.

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
### New Feature Checklist
- [x] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [x] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
