### PR TITLE
Update pin to newer fsspec versions.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
     "astropy",
-    "fsspec<=2023.9.2", # Used for abstract filesystems
+    "fsspec>=2023.10.0", # Used for abstract filesystems
     "healpy",
     "numba>=0.58",
     "numpy", 

--- a/src/hipscat/io/file_io/file_pointer.py
+++ b/src/hipscat/io/file_io/file_pointer.py
@@ -65,7 +65,7 @@ def get_file_pointer_for_fs(protocol: str, file_pointer: FilePointer) -> FilePoi
     if not isinstance(file_pointer, str):
         file_pointer = str(file_pointer)
 
-    if protocol == "file":
+    if "file" in protocol:
         # return the entire filepath for local files
         if "file://" in file_pointer:
             split_pointer = file_pointer.split("file://")[1]
@@ -117,7 +117,7 @@ def strip_leading_slash_for_pyarrow(pointer: FilePointer, protocol: str) -> File
     Returns:
         New file pointer with leading slash removed.
     """
-    if protocol != "file" and str(pointer).startswith("/"):
+    if "file" not in protocol and str(pointer).startswith("/"):
         pointer = FilePointer(str(pointer).replace("/", "", 1))
     return pointer
 

--- a/tests/hipscat/io/file_io/test_file_pointers.py
+++ b/tests/hipscat/io/file_io/test_file_pointers.py
@@ -112,7 +112,7 @@ def test_get_directory_contents(small_sky_order1_dir, tmp_path):
 
 def test_get_fs():
     filesystem, _ = get_fs("file://")
-    assert filesystem.protocol == "file"
+    assert "file" in filesystem.protocol
 
     # this will fail if the environment installs lakefs to import
     with pytest.raises(ImportError):


### PR DESCRIPTION
See https://github.com/astronomy-commons/lsdb/issues/294

Moves the fsspec version pin to *after* the breaking change that treats the protocol as a tuple.