### PR TITLE
Suppress color bar for constant order plot

### DIFF
--- a/src/hipscat/inspection/visualize_catalog.py
+++ b/src/hipscat/inspection/visualize_catalog.py
@@ -81,9 +81,10 @@ def plot_pixel_list(pixels: List[HealpixPixel], plot_title: str = "", projection
     min_order = np.min(pixels).order
 
     if max_order == min_order:
-        color = plt.cm.viridis(0.5)  # pylint: disable=no-member
-        colors = [plt.cm.viridis(0.0), color]  # pylint: disable=no-member
-        cmap = mcolors.LinearSegmentedColormap.from_list("my_colormap", colors)
+        colors = [plt.cm.viridis(0.0), plt.cm.viridis(0.1)]  # pylint: disable=no-member
+        cmap = mcolors.LinearSegmentedColormap.from_list("my_colormap", colors, 1)
+        kwargs["cbar"] = False
+        plot_title = f"Norder {max_order} {plot_title}"
     else:
         num_colors = max_order - min_order + 1
         colors = plt.cm.viridis(np.linspace(0, 1, num_colors))  # pylint: disable=no-member


### PR DESCRIPTION
Suppresses the color bar legend if the pixel list contains only one healpix Norder.

![Figure_1](https://github.com/astronomy-commons/hipscat/assets/113376043/df44c9d0-3ef0-4f58-b807-93aafa907933)

Using the `healpy.visufunc.mollview` method, we don't have a lot of control over the color bar tick marks. The under-construction `healpy.newvisufunc.projview` method makes this problem easier, but does not yet support masking (e.g. the gray background for areas where there is no catalog coverage).