### PR TITLE
Add MOC filter and alignment methods

### DIFF
--- a/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
@@ -148,8 +148,31 @@ class HealpixDataset(Dataset):
     def align(
         self, other_cat: Self, alignment_type: PixelAlignmentType = PixelAlignmentType.INNER
     ) -> PixelAlignment:
+        """Performs an alignment to another catalog, using the pixel tree and mocs if available
+
+        An alignment compares the pixel structures of the two catalogs, checking which pixels overlap.
+        The alignment includes the mapping of all pairs of pixels in each tree that overlap with each other,
+        and the aligned tree which consists of the overlapping pixels in the two input catalogs, using the
+        higher order pixels where there is overlap with differing orders.
+
+        For more information, see this document:
+        https://docs.google.com/document/d/1gqb8qb3HiEhLGNav55LKKFlNjuusBIsDW7FdTkc5mJU/edit?usp=sharing
+
+        Args:
+            other_cat (Catalog): The catalog to align to
+            alignment_type (PixelAlignmentType): The type of alignment describing how to handle nodes which
+            exist in one tree but not the other. Mirrors the 'how' argument of a pandas/sql join. Options are:
+
+                - "inner" - only use pixels that appear in both catalogs
+                - "left" - use all pixels that appear in the left catalog and any overlapping from the right
+                - "right" - use all pixels that appear in the right catalog and any overlapping from the left
+                - "outer" - use all pixels from both catalogs
+
+        Returns (PixelAlignment):
+            A `PixelAlignment` object with the alignment from the two catalogs
+        """
         left_moc = self.moc if self.moc is not None else self.pixel_tree.to_moc()
-        right_moc = other_cat.moc if other_cat is not None else other_cat.pixel_tree.to_moc()
+        right_moc = other_cat.moc if other_cat.moc is not None else other_cat.pixel_tree.to_moc()
         return align_with_mocs(
             self.pixel_tree, other_cat.pixel_tree, left_moc, right_moc, alignment_type=alignment_type
         )

--- a/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
@@ -13,6 +13,9 @@ from hipscat.catalog.dataset import BaseCatalogInfo, Dataset
 from hipscat.catalog.partition_info import PartitionInfo
 from hipscat.io import FilePointer, file_io, paths
 from hipscat.pixel_math import HealpixPixel
+from hipscat.pixel_tree import PixelAlignmentType, PixelAlignment
+from hipscat.pixel_tree.moc_filter import filter_by_moc
+from hipscat.pixel_tree.pixel_alignment import align_with_mocs
 from hipscat.pixel_tree.pixel_tree import PixelTree
 
 PixelInputTypes = Union[PartitionInfo, PixelTree, List[HealpixPixel]]
@@ -141,3 +144,12 @@ class HealpixDataset(Dataset):
         """
         filtered_catalog_info = dataclasses.replace(self.catalog_info, total_rows=None)
         return self.__class__(filtered_catalog_info, pixels)
+
+    def align(
+        self, other_cat: Self, alignment_type: PixelAlignmentType = PixelAlignmentType.INNER
+    ) -> PixelAlignment:
+        left_moc = self.moc if self.moc is not None else self.pixel_tree.to_moc()
+        right_moc = other_cat.moc if other_cat is not None else other_cat.pixel_tree.to_moc()
+        return align_with_mocs(
+            self.pixel_tree, other_cat.pixel_tree, left_moc, right_moc, alignment_type=alignment_type
+        )

--- a/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
@@ -13,8 +13,7 @@ from hipscat.catalog.dataset import BaseCatalogInfo, Dataset
 from hipscat.catalog.partition_info import PartitionInfo
 from hipscat.io import FilePointer, file_io, paths
 from hipscat.pixel_math import HealpixPixel
-from hipscat.pixel_tree import PixelAlignmentType, PixelAlignment
-from hipscat.pixel_tree.moc_filter import filter_by_moc
+from hipscat.pixel_tree import PixelAlignment, PixelAlignmentType
 from hipscat.pixel_tree.pixel_alignment import align_with_mocs
 from hipscat.pixel_tree.pixel_tree import PixelTree
 

--- a/src/hipscat/pixel_tree/moc_filter.py
+++ b/src/hipscat/pixel_tree/moc_filter.py
@@ -23,20 +23,7 @@ def filter_by_moc(
     # Convert tree intervals to order 29 to match moc intervals
     tree_29_ranges = tree.tree << (2 * (29 - tree.tree_order))
     tree_mask = perform_filter_by_moc(tree_29_ranges, moc_ranges)
-    return filter_tree_by_mask(tree, tree_mask)
-
-
-def filter_tree_by_mask(tree: PixelTree, mask: np.ndarray) -> PixelTree:
-    """Applies a boolean mask to a pixel tree to filter which pixels are in the tree
-
-    Args:
-        tree (PixelTree): The pixel tree to filter
-        mask (np.ndarray): The mask to filter by
-
-    Returns:
-        A new PixelTree object with only the pixels from the mask, at the same tree order as the original tree
-    """
-    return PixelTree(tree.tree[mask], tree.tree_order)
+    return PixelTree(tree.tree[tree_mask], tree.tree_order)
 
 
 @njit(

--- a/src/hipscat/pixel_tree/moc_filter.py
+++ b/src/hipscat/pixel_tree/moc_filter.py
@@ -10,6 +10,15 @@ def filter_by_moc(
     tree: PixelTree,
     moc: MOC,
 ) -> PixelTree:
+    """Filters a pixel tree to only include the pixels that overlap with the pixels in the moc
+
+    Args:
+        tree (PixelTree): The tree to perform the filtering on
+        moc (mocpy.MOC): The moc to use to filter
+
+    Returns:
+        A new PixelTree object with only the pixels from the input tree that overlap with the moc.
+    """
     moc_ranges = moc.to_depth29_ranges
     tree_29_ranges = tree.tree << (2 * (29 - tree.tree_order))
     tree_mask = perform_filter_by_moc(tree_29_ranges, moc_ranges)
@@ -26,7 +35,18 @@ def perform_filter_by_moc(
     tree: np.ndarray,
     moc: np.ndarray,
 ) -> np.ndarray:
-    """Performs filtering with lists of pixel intervals"""
+    """Performs filtering with lists of pixel intervals
+
+    Input interval lists must be at the same order.
+
+    Args:
+        tree (np.ndarray): Array of pixel intervals to be filtered
+        moc (np.ndarray): Array of pixel intervals to be used to filter
+
+    Returns:
+        A boolean array of dimension tree.shape[0] which masks which pixels in tree overlap with the pixels in
+        moc
+    """
     output = np.full(tree.shape[0], fill_value=False, dtype=np.bool_)
     tree_index = 0
     moc_index = 0

--- a/src/hipscat/pixel_tree/moc_filter.py
+++ b/src/hipscat/pixel_tree/moc_filter.py
@@ -20,9 +20,23 @@ def filter_by_moc(
         A new PixelTree object with only the pixels from the input tree that overlap with the moc.
     """
     moc_ranges = moc.to_depth29_ranges
+    # Convert tree intervals to order 29 to match moc intervals
     tree_29_ranges = tree.tree << (2 * (29 - tree.tree_order))
     tree_mask = perform_filter_by_moc(tree_29_ranges, moc_ranges)
-    return PixelTree(tree.tree[tree_mask], tree.tree_order)
+    return filter_tree_by_mask(tree, tree_mask)
+
+
+def filter_tree_by_mask(tree: PixelTree, mask: np.ndarray) -> PixelTree:
+    """Applies a boolean mask to a pixel tree to filter which pixels are in the tree
+
+    Args:
+        tree (PixelTree): The pixel tree to filter
+        mask (np.ndarray): The mask to filter by
+
+    Returns:
+        A new PixelTree object with only the pixels from the mask, at the same tree order as the original tree
+    """
+    return PixelTree(tree.tree[mask], tree.tree_order)
 
 
 @njit(
@@ -34,7 +48,7 @@ def filter_by_moc(
 def perform_filter_by_moc(
     tree: np.ndarray,
     moc: np.ndarray,
-) -> np.ndarray:
+) -> np.ndarray:  # pragma: no cover
     """Performs filtering with lists of pixel intervals
 
     Input interval lists must be at the same order.

--- a/src/hipscat/pixel_tree/moc_filter.py
+++ b/src/hipscat/pixel_tree/moc_filter.py
@@ -1,0 +1,47 @@
+import numba
+import numpy as np
+from mocpy import MOC
+from numba import njit
+
+from hipscat.pixel_tree.pixel_tree import PixelTree
+
+
+def filter_by_moc(
+    tree: PixelTree,
+    moc: MOC,
+) -> PixelTree:
+    moc_ranges = moc.to_depth29_ranges
+    tree_29_ranges = tree.tree << (2 * (29 - tree.tree_order))
+    tree_mask = perform_filter_by_moc(tree_29_ranges, moc_ranges)
+    return PixelTree(tree.tree[tree_mask], tree.tree_order)
+
+
+@njit(
+    numba.bool_[::1](
+        numba.int64[:, :],
+        numba.uint64[:, :],
+    )
+)
+def perform_filter_by_moc(
+    tree: np.ndarray,
+    moc: np.ndarray,
+) -> np.ndarray:
+    """Performs filtering with lists of pixel intervals"""
+    output = np.full(tree.shape[0], fill_value=False, dtype=np.bool_)
+    tree_index = 0
+    moc_index = 0
+    while tree_index < len(tree) and moc_index < len(moc):
+        tree_pix = tree[tree_index]
+        moc_pix = moc[moc_index]
+        if tree_pix[0] >= moc_pix[1]:
+            # Don't overlap, tree pixel ahead so move onto next MOC pixel
+            moc_index += 1
+            continue
+        if moc_pix[0] >= tree_pix[1]:
+            # Don't overlap, MOC pixel ahead so move onto next tree pixel
+            tree_index += 1
+            continue
+        # Pixels overlap, so include current tree pixel and check next tree pixel
+        output[tree_index] = True
+        tree_index += 1
+    return output

--- a/src/hipscat/pixel_tree/pixel_alignment.py
+++ b/src/hipscat/pixel_tree/pixel_alignment.py
@@ -7,7 +7,7 @@ from mocpy import MOC
 from numba import njit
 
 from hipscat.pixel_math.healpix_pixel_function import get_pixels_from_intervals
-from hipscat.pixel_tree.moc_filter import filter_tree_by_mask, perform_filter_by_moc
+from hipscat.pixel_tree.moc_filter import perform_filter_by_moc
 from hipscat.pixel_tree.pixel_alignment_types import PixelAlignmentType
 from hipscat.pixel_tree.pixel_tree import PixelTree
 
@@ -404,7 +404,7 @@ def filter_alignment_by_moc(alignment: PixelAlignment, moc: MOC) -> PixelAlignme
     moc_ranges = moc.to_depth29_ranges
     tree_29_ranges = alignment.pixel_tree.tree << (2 * (29 - alignment.pixel_tree.tree_order))
     tree_mask = perform_filter_by_moc(tree_29_ranges, moc_ranges)
-    new_tree = filter_tree_by_mask(alignment.pixel_tree, tree_mask)
+    new_tree = PixelTree(alignment.pixel_tree.tree[tree_mask], alignment.pixel_tree.tree_order)
     return PixelAlignment(new_tree, alignment.pixel_mapping.iloc[tree_mask], alignment.alignment_type)
 
 

--- a/src/hipscat/pixel_tree/pixel_alignment.py
+++ b/src/hipscat/pixel_tree/pixel_alignment.py
@@ -7,7 +7,7 @@ from mocpy import MOC
 from numba import njit
 
 from hipscat.pixel_math.healpix_pixel_function import get_pixels_from_intervals
-from hipscat.pixel_tree.moc_filter import perform_filter_by_moc, filter_tree_by_mask
+from hipscat.pixel_tree.moc_filter import filter_tree_by_mask, perform_filter_by_moc
 from hipscat.pixel_tree.pixel_alignment_types import PixelAlignmentType
 from hipscat.pixel_tree.pixel_tree import PixelTree
 

--- a/src/hipscat/pixel_tree/pixel_alignment.py
+++ b/src/hipscat/pixel_tree/pixel_alignment.py
@@ -7,7 +7,7 @@ from mocpy import MOC
 from numba import njit
 
 from hipscat.pixel_math.healpix_pixel_function import get_pixels_from_intervals
-from hipscat.pixel_tree.moc_filter import perform_filter_by_moc
+from hipscat.pixel_tree.moc_filter import perform_filter_by_moc, filter_tree_by_mask
 from hipscat.pixel_tree.pixel_alignment_types import PixelAlignmentType
 from hipscat.pixel_tree.pixel_tree import PixelTree
 
@@ -404,7 +404,7 @@ def filter_alignment_by_moc(alignment: PixelAlignment, moc: MOC) -> PixelAlignme
     moc_ranges = moc.to_depth29_ranges
     tree_29_ranges = alignment.pixel_tree.tree << (2 * (29 - alignment.pixel_tree.tree_order))
     tree_mask = perform_filter_by_moc(tree_29_ranges, moc_ranges)
-    new_tree = PixelTree(alignment.pixel_tree.tree[tree_mask], alignment.pixel_tree.tree_order)
+    new_tree = filter_tree_by_mask(alignment.pixel_tree, tree_mask)
     return PixelAlignment(new_tree, alignment.pixel_mapping.iloc[tree_mask], alignment.alignment_type)
 
 

--- a/src/hipscat/pixel_tree/pixel_alignment.py
+++ b/src/hipscat/pixel_tree/pixel_alignment.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Callable
+from typing import Callable, Dict, List
 
 import numba
 import numpy as np
@@ -391,6 +391,16 @@ def perform_align_trees(
 
 
 def filter_alignment_by_moc(alignment: PixelAlignment, moc: MOC) -> PixelAlignment:
+    """Filters an alignment by a moc to only include pixels in the aligned_tree that overlap with the moc,
+    and the corresponding rows in the mapping.
+
+    Args:
+        alignment (PixelAlignment): The pixel alignment to filter
+        moc (mocpy.MOC): The moc to filter by
+
+    Returns:
+        PixelAlignment object with the filtered mapping and tree
+    """
     moc_ranges = moc.to_depth29_ranges
     tree_29_ranges = alignment.pixel_tree.tree << (2 * (29 - alignment.pixel_tree.tree_order))
     tree_mask = perform_filter_by_moc(tree_29_ranges, moc_ranges)
@@ -399,8 +409,31 @@ def filter_alignment_by_moc(alignment: PixelAlignment, moc: MOC) -> PixelAlignme
 
 
 def align_with_mocs(
-    left_tree, right_tree, left_moc, right_moc, alignment_type: PixelAlignmentType = PixelAlignmentType.INNER
-):
+    left_tree: PixelTree,
+    right_tree: PixelTree,
+    left_moc: MOC,
+    right_moc: MOC,
+    alignment_type: PixelAlignmentType = PixelAlignmentType.INNER,
+) -> PixelAlignment:
+    """Aligns two pixel trees and mocs together, resulting in a pixel alignment with only aligned pixels that
+    have coverage in the mocs.
+
+    Args:
+        left_tree (PixelTree): The left tree to align
+        right_tree (PixelTree): The right tree to align
+        left_moc (mocpy.MOC): the moc with the coverage of the left catalog
+        right_moc (mocpy.MOC): the moc with the coverage of the right catalog
+        alignment_type (PixelAlignmentType): The type of alignment describing how to handle nodes which exist
+            in one tree but not the other. Options are:
+
+                - inner - only use pixels that appear in both catalogs
+                - left - use all pixels that appear in the left catalog and any overlapping from the right
+                - right - use all pixels that appear in the right catalog and any overlapping from the left
+                - outer - use all pixels from both catalogs
+
+    Returns:
+        The PixelAlignment object with the aligned trees filtered by the coverage in the catalogs.
+    """
     moc_intersection_methods: Dict[PixelAlignmentType, Callable[[MOC, MOC], MOC]] = {
         PixelAlignmentType.INNER: lambda l, r: l.intersection(r),
         PixelAlignmentType.LEFT: lambda l, r: l,

--- a/src/hipscat/pixel_tree/pixel_tree.py
+++ b/src/hipscat/pixel_tree/pixel_tree.py
@@ -88,6 +88,7 @@ class PixelTree:
         return [HealpixPixel(p[0], p[1]) for p in self.pixels]
 
     def to_moc(self) -> MOC:
+        """Returns the MOC object that covers the same pixels as the tree"""
         return MOC.from_healpix_cells(self.pixels.T[1], self.pixels.T[0], self.tree_order)
 
     @classmethod

--- a/src/hipscat/pixel_tree/pixel_tree.py
+++ b/src/hipscat/pixel_tree/pixel_tree.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import List, Sequence
 
 import numpy as np
+from mocpy import MOC
 
 from hipscat.pixel_math import HealpixInputTypes, HealpixPixel
 from hipscat.pixel_math.healpix_pixel_convertor import get_healpix_tuple
@@ -84,7 +85,10 @@ class PixelTree:
         Returns (List[HealpixPixel]):
             A list of the HEALPix pixels in the tree
         """
-        return np.vectorize(HealpixPixel)(self.pixels.T[0], self.pixels.T[1])
+        return [HealpixPixel(p[0], p[1]) for p in self.pixels]
+
+    def to_moc(self) -> MOC:
+        return MOC.from_healpix_cells(self.pixels.T[1], self.pixels.T[0], self.tree_order)
 
     @classmethod
     def from_healpix(cls, healpix_pixels: Sequence[HealpixInputTypes], tree_order=None) -> PixelTree:

--- a/tests/hipscat/conftest.py
+++ b/tests/hipscat/conftest.py
@@ -1,17 +1,9 @@
-import numpy as np
 import pytest
 
 from hipscat.loaders import read_from_hipscat
 from hipscat.pixel_math import HealpixPixel
-from hipscat.pixel_tree.pixel_tree import PixelTree
-
 
 # pylint: disable= redefined-outer-name
-
-
-def assert_trees_equal(tree1: PixelTree, tree2: PixelTree):
-    np.testing.assert_array_equal(tree1.tree, tree2.tree)
-    assert tree1.tree_order == tree2.tree_order
 
 
 @pytest.fixture

--- a/tests/hipscat/conftest.py
+++ b/tests/hipscat/conftest.py
@@ -1,9 +1,17 @@
+import numpy as np
 import pytest
 
 from hipscat.loaders import read_from_hipscat
 from hipscat.pixel_math import HealpixPixel
+from hipscat.pixel_tree.pixel_tree import PixelTree
+
 
 # pylint: disable= redefined-outer-name
+
+
+def assert_trees_equal(tree1: PixelTree, tree2: PixelTree):
+    np.testing.assert_array_equal(tree1.tree, tree2.tree)
+    assert tree1.tree_order == tree2.tree_order
 
 
 @pytest.fixture

--- a/tests/hipscat/pixel_tree/conftest.py
+++ b/tests/hipscat/pixel_tree/conftest.py
@@ -19,23 +19,21 @@ def pixel_tree_1():
 @pytest.fixture
 def pixel_tree_2_pixels():
     return [
-            HealpixPixel(2, 128),
-            HealpixPixel(2, 130),
-            HealpixPixel(2, 131),
-            HealpixPixel(1, 33),
-            HealpixPixel(1, 35),
-            HealpixPixel(0, 10),
-            HealpixPixel(1, 44),
-            HealpixPixel(1, 45),
-            HealpixPixel(1, 46),
-        ]
+        HealpixPixel(2, 128),
+        HealpixPixel(2, 130),
+        HealpixPixel(2, 131),
+        HealpixPixel(1, 33),
+        HealpixPixel(1, 35),
+        HealpixPixel(0, 10),
+        HealpixPixel(1, 44),
+        HealpixPixel(1, 45),
+        HealpixPixel(1, 46),
+    ]
 
 
 @pytest.fixture
 def pixel_tree_2(pixel_tree_2_pixels):
-    return PixelTree.from_healpix(
-        pixel_tree_2_pixels
-    )
+    return PixelTree.from_healpix(pixel_tree_2_pixels)
 
 
 @pytest.fixture

--- a/tests/hipscat/pixel_tree/conftest.py
+++ b/tests/hipscat/pixel_tree/conftest.py
@@ -17,19 +17,24 @@ def pixel_tree_1():
 
 
 @pytest.fixture
-def pixel_tree_2():
-    return PixelTree.from_healpix(
-        [
-            HealpixPixel(0, 10),
-            HealpixPixel(1, 33),
-            HealpixPixel(1, 35),
-            HealpixPixel(1, 44),
-            HealpixPixel(1, 45),
-            HealpixPixel(1, 46),
+def pixel_tree_2_pixels():
+    return [
             HealpixPixel(2, 128),
             HealpixPixel(2, 130),
             HealpixPixel(2, 131),
+            HealpixPixel(1, 33),
+            HealpixPixel(1, 35),
+            HealpixPixel(0, 10),
+            HealpixPixel(1, 44),
+            HealpixPixel(1, 45),
+            HealpixPixel(1, 46),
         ]
+
+
+@pytest.fixture
+def pixel_tree_2(pixel_tree_2_pixels):
+    return PixelTree.from_healpix(
+        pixel_tree_2_pixels
     )
 
 

--- a/tests/hipscat/pixel_tree/test_moc_filter.py
+++ b/tests/hipscat/pixel_tree/test_moc_filter.py
@@ -23,12 +23,12 @@ def test_moc_filter_lower_order(pixel_tree_2):
     moc = MOC.from_healpix_cells(pixels, orders, 1)
     filtered_tree = filter_by_moc(pixel_tree_2, moc)
     assert filtered_tree.get_healpix_pixels() == [
-            HealpixPixel(2, 128),
-            HealpixPixel(2, 130),
-            HealpixPixel(2, 131),
-            HealpixPixel(1, 44),
-            HealpixPixel(1, 45),
-            HealpixPixel(1, 46),
+        HealpixPixel(2, 128),
+        HealpixPixel(2, 130),
+        HealpixPixel(2, 131),
+        HealpixPixel(1, 44),
+        HealpixPixel(1, 45),
+        HealpixPixel(1, 46),
     ]
 
 
@@ -38,8 +38,8 @@ def test_moc_filter_higher_order(pixel_tree_2):
     moc = MOC.from_healpix_cells(pixels, orders, 3)
     filtered_tree = filter_by_moc(pixel_tree_2, moc)
     assert filtered_tree.get_healpix_pixels() == [
-            HealpixPixel(2, 130),
-            HealpixPixel(0, 10),
+        HealpixPixel(2, 130),
+        HealpixPixel(0, 10),
     ]
 
 

--- a/tests/hipscat/pixel_tree/test_moc_filter.py
+++ b/tests/hipscat/pixel_tree/test_moc_filter.py
@@ -1,0 +1,59 @@
+import numpy as np
+from mocpy import MOC
+
+from hipscat.pixel_math import HealpixPixel
+from hipscat.pixel_tree.moc_filter import filter_by_moc
+
+
+def test_moc_filter(pixel_tree_2):
+    orders = np.array([1, 1, 2])
+    pixels = np.array([45, 46, 128])
+    moc = MOC.from_healpix_cells(pixels, orders, 2)
+    filtered_tree = filter_by_moc(pixel_tree_2, moc)
+    assert filtered_tree.get_healpix_pixels() == [
+        HealpixPixel(2, 128),
+        HealpixPixel(1, 45),
+        HealpixPixel(1, 46),
+    ]
+
+
+def test_moc_filter_lower_order(pixel_tree_2):
+    orders = np.array([0, 1])
+    pixels = np.array([11, 32])
+    moc = MOC.from_healpix_cells(pixels, orders, 1)
+    filtered_tree = filter_by_moc(pixel_tree_2, moc)
+    assert filtered_tree.get_healpix_pixels() == [
+            HealpixPixel(2, 128),
+            HealpixPixel(2, 130),
+            HealpixPixel(2, 131),
+            HealpixPixel(1, 44),
+            HealpixPixel(1, 45),
+            HealpixPixel(1, 46),
+    ]
+
+
+def test_moc_filter_higher_order(pixel_tree_2):
+    orders = np.array([1, 3])
+    pixels = np.array([40, 520])
+    moc = MOC.from_healpix_cells(pixels, orders, 3)
+    filtered_tree = filter_by_moc(pixel_tree_2, moc)
+    assert filtered_tree.get_healpix_pixels() == [
+            HealpixPixel(2, 130),
+            HealpixPixel(0, 10),
+    ]
+
+
+def test_moc_filter_empty_moc(pixel_tree_2):
+    orders = np.array([])
+    pixels = np.array([])
+    moc = MOC.from_healpix_cells(pixels, orders, 0)
+    filtered_tree = filter_by_moc(pixel_tree_2, moc)
+    assert filtered_tree.get_healpix_pixels() == []
+
+
+def test_moc_filter_empty_result(pixel_tree_2):
+    orders = np.array([0])
+    pixels = np.array([1])
+    moc = MOC.from_healpix_cells(pixels, orders, 0)
+    filtered_tree = filter_by_moc(pixel_tree_2, moc)
+    assert filtered_tree.get_healpix_pixels() == []

--- a/tests/hipscat/pixel_tree/test_pixel_alignment.py
+++ b/tests/hipscat/pixel_tree/test_pixel_alignment.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from hipscat.catalog import Catalog
 from hipscat.pixel_math import HealpixPixel
-from hipscat.pixel_tree.pixel_alignment import align_trees, align_with_mocs, PixelAlignment
+from hipscat.pixel_tree.pixel_alignment import PixelAlignment, align_trees, align_with_mocs
 from hipscat.pixel_tree.pixel_tree import PixelTree
 
 

--- a/tests/hipscat/pixel_tree/test_pixel_alignment.py
+++ b/tests/hipscat/pixel_tree/test_pixel_alignment.py
@@ -1,33 +1,244 @@
 import numpy as np
 
-from hipscat.pixel_tree.pixel_alignment import align_trees
+from hipscat.catalog import Catalog
+from hipscat.pixel_math import HealpixPixel
+from hipscat.pixel_tree.pixel_alignment import align_trees, align_with_mocs, PixelAlignment
 from hipscat.pixel_tree.pixel_tree import PixelTree
 
 
 def assert_trees_equal(tree1: PixelTree, tree2: PixelTree):
     np.testing.assert_array_equal(tree1.tree, tree2.tree)
+    assert tree1.tree_order == tree2.tree_order
+
+
+def assert_mapping_matches_tree(alignment: PixelAlignment):
+    for (_, row), pixel in zip(alignment.pixel_mapping.iterrows(), alignment.pixel_tree.get_healpix_pixels()):
+        left_pixel = (
+            HealpixPixel(
+                row[PixelAlignment.PRIMARY_ORDER_COLUMN_NAME], row[PixelAlignment.PRIMARY_PIXEL_COLUMN_NAME]
+            )
+            if row[PixelAlignment.PRIMARY_ORDER_COLUMN_NAME] is not None
+            else None
+        )
+        right_pixel = (
+            HealpixPixel(
+                row[PixelAlignment.JOIN_ORDER_COLUMN_NAME], row[PixelAlignment.JOIN_PIXEL_COLUMN_NAME]
+            )
+            if row[PixelAlignment.JOIN_ORDER_COLUMN_NAME] is not None
+            else None
+        )
+        aligned_pixel = (
+            HealpixPixel(
+                row[PixelAlignment.ALIGNED_ORDER_COLUMN_NAME], row[PixelAlignment.ALIGNED_PIXEL_COLUMN_NAME]
+            )
+            if row[PixelAlignment.ALIGNED_ORDER_COLUMN_NAME] is not None
+            else None
+        )
+        assert pixel == aligned_pixel
+        if left_pixel is not None:
+            assert aligned_pixel.convert_to_lower_order(aligned_pixel.order - left_pixel.order) == left_pixel
+        if right_pixel is not None:
+            assert (
+                aligned_pixel.convert_to_lower_order(aligned_pixel.order - right_pixel.order) == right_pixel
+            )
 
 
 def test_pixel_tree_alignment_same_tree(pixel_tree_1):
     alignment = align_trees(pixel_tree_1, pixel_tree_1, "inner")
     assert_trees_equal(pixel_tree_1, alignment.pixel_tree)
+    assert_mapping_matches_tree(alignment)
 
 
 def test_pixel_tree_alignment_inner(pixel_tree_2, pixel_tree_3, aligned_trees_2_3_inner):
     alignment = align_trees(pixel_tree_2, pixel_tree_3, "inner")
     assert_trees_equal(alignment.pixel_tree, aligned_trees_2_3_inner)
+    assert_mapping_matches_tree(alignment)
 
 
 def test_pixel_tree_alignment_left(pixel_tree_2, pixel_tree_3, aligned_trees_2_3_left):
     alignment = align_trees(pixel_tree_2, pixel_tree_3, "left")
     assert_trees_equal(alignment.pixel_tree, aligned_trees_2_3_left)
+    assert_mapping_matches_tree(alignment)
 
 
 def test_pixel_tree_alignment_right(pixel_tree_2, pixel_tree_3, aligned_trees_2_3_right):
     alignment = align_trees(pixel_tree_2, pixel_tree_3, "right")
     assert_trees_equal(alignment.pixel_tree, aligned_trees_2_3_right)
+    assert_mapping_matches_tree(alignment)
 
 
 def test_pixel_tree_alignment_outer(pixel_tree_2, pixel_tree_3, aligned_trees_2_3_outer):
     alignment = align_trees(pixel_tree_2, pixel_tree_3, "outer")
     assert_trees_equal(alignment.pixel_tree, aligned_trees_2_3_outer)
+    assert_mapping_matches_tree(alignment)
+
+
+def test_pixel_tree_alignment_with_moc_inner(pixel_tree_2, pixel_tree_3, aligned_trees_2_3_inner):
+    moc_pixels = aligned_trees_2_3_inner.get_healpix_pixels()[:-3]
+    correct_aligned_tree = PixelTree.from_healpix(moc_pixels)
+    moc = correct_aligned_tree.to_moc()
+    alignment = align_with_mocs(pixel_tree_2, pixel_tree_3, moc, pixel_tree_3.to_moc())
+    assert_trees_equal(alignment.pixel_tree, correct_aligned_tree)
+    assert_mapping_matches_tree(alignment)
+    alignment = align_with_mocs(pixel_tree_2, pixel_tree_3, pixel_tree_2.to_moc(), moc)
+    assert_trees_equal(alignment.pixel_tree, correct_aligned_tree)
+    assert_mapping_matches_tree(alignment)
+
+
+def test_pixel_tree_alignment_with_moc_same(pixel_tree_2, pixel_tree_3, aligned_trees_2_3_inner):
+    alignment = align_with_mocs(pixel_tree_2, pixel_tree_3, pixel_tree_2.to_moc(), pixel_tree_3.to_moc())
+    assert_trees_equal(alignment.pixel_tree, aligned_trees_2_3_inner)
+    assert_mapping_matches_tree(alignment)
+
+
+def test_pixel_tree_alignment_with_moc_left(pixel_tree_2, pixel_tree_3, aligned_trees_2_3_left):
+    moc_pixels = aligned_trees_2_3_left.get_healpix_pixels()[:-3]
+    correct_aligned_tree = PixelTree.from_healpix(moc_pixels)
+    moc = correct_aligned_tree.to_moc()
+
+    alignment = align_with_mocs(pixel_tree_2, pixel_tree_3, moc, pixel_tree_3.to_moc(), alignment_type="left")
+    assert_trees_equal(alignment.pixel_tree, correct_aligned_tree)
+    assert_mapping_matches_tree(alignment)
+
+    alignment = align_with_mocs(pixel_tree_2, pixel_tree_3, pixel_tree_2.to_moc(), moc, alignment_type="left")
+    assert_trees_equal(alignment.pixel_tree, aligned_trees_2_3_left)
+    assert_mapping_matches_tree(alignment)
+
+
+def test_pixel_tree_alignment_with_moc_right(pixel_tree_2, pixel_tree_3, aligned_trees_2_3_right):
+    moc_pixels = aligned_trees_2_3_right.get_healpix_pixels()[:-3]
+    correct_aligned_tree = PixelTree.from_healpix(moc_pixels)
+    moc = correct_aligned_tree.to_moc()
+
+    alignment = align_with_mocs(
+        pixel_tree_2, pixel_tree_3, moc, pixel_tree_3.to_moc(), alignment_type="right"
+    )
+    assert_trees_equal(alignment.pixel_tree, aligned_trees_2_3_right)
+    assert_mapping_matches_tree(alignment)
+
+    alignment = align_with_mocs(
+        pixel_tree_2, pixel_tree_3, pixel_tree_2.to_moc(), moc, alignment_type="right"
+    )
+    assert_trees_equal(alignment.pixel_tree, correct_aligned_tree)
+    assert_mapping_matches_tree(alignment)
+
+
+def test_pixel_tree_alignment_with_moc_outer(pixel_tree_2, pixel_tree_3, aligned_trees_2_3_outer):
+    moc_pixels = aligned_trees_2_3_outer.get_healpix_pixels()[:-3]
+    moc = PixelTree.from_healpix(moc_pixels).to_moc()
+    # moc doesn't include pixels (1,45), (1,46), (1,47). Outer align with right tree moc includes 46 and 47
+    # from right tree
+    left_moc_correct_tree = PixelTree.from_healpix(moc_pixels + [HealpixPixel(1, 46), HealpixPixel(1, 47)])
+    alignment = align_with_mocs(
+        pixel_tree_2, pixel_tree_3, moc, pixel_tree_3.to_moc(), alignment_type="outer"
+    )
+    assert_trees_equal(alignment.pixel_tree, left_moc_correct_tree)
+    assert_mapping_matches_tree(alignment)
+
+    # moc doesn't include pixels (1,45), (1,46), (1,47). Outer align with left tree moc includes 45 and 46
+    # from left tree
+    right_moc_correct_tree = PixelTree.from_healpix(moc_pixels + [HealpixPixel(1, 45), HealpixPixel(1, 46)])
+    alignment = align_with_mocs(
+        pixel_tree_2, pixel_tree_3, pixel_tree_2.to_moc(), moc, alignment_type="outer"
+    )
+    assert_trees_equal(alignment.pixel_tree, right_moc_correct_tree)
+    assert_mapping_matches_tree(alignment)
+
+    both_moc_correct_tree = PixelTree.from_healpix(moc_pixels)
+    alignment = align_with_mocs(pixel_tree_2, pixel_tree_3, moc, moc, alignment_type="outer")
+    assert_trees_equal(alignment.pixel_tree, both_moc_correct_tree)
+    assert_mapping_matches_tree(alignment)
+
+
+def test_catalog_align_inner(pixel_tree_2, pixel_tree_3, aligned_trees_2_3_inner, catalog_info):
+    left_cat = Catalog(catalog_info, pixel_tree_2)
+    right_cat = Catalog(catalog_info, pixel_tree_3)
+    alignment = left_cat.align(right_cat)
+    assert_trees_equal(alignment.pixel_tree, aligned_trees_2_3_inner)
+    assert_mapping_matches_tree(alignment)
+
+    moc_pixels = aligned_trees_2_3_inner.get_healpix_pixels()[:-3]
+    correct_aligned_tree = PixelTree.from_healpix(moc_pixels)
+    moc = correct_aligned_tree.to_moc()
+
+    left_cat_with_moc = Catalog(catalog_info, pixel_tree_2, moc=moc)
+    alignment = left_cat_with_moc.align(right_cat)
+    assert_trees_equal(alignment.pixel_tree, correct_aligned_tree)
+    assert_mapping_matches_tree(alignment)
+
+    right_cat_with_moc = Catalog(catalog_info, pixel_tree_3, moc=moc)
+    alignment = left_cat.align(right_cat_with_moc)
+    assert_trees_equal(alignment.pixel_tree, correct_aligned_tree)
+    assert_mapping_matches_tree(alignment)
+
+
+def test_catalog_align_left(pixel_tree_2, pixel_tree_3, aligned_trees_2_3_left, catalog_info):
+    left_cat = Catalog(catalog_info, pixel_tree_2)
+    right_cat = Catalog(catalog_info, pixel_tree_3)
+    alignment = left_cat.align(right_cat, alignment_type="left")
+    assert_trees_equal(alignment.pixel_tree, aligned_trees_2_3_left)
+    assert_mapping_matches_tree(alignment)
+
+    moc_pixels = aligned_trees_2_3_left.get_healpix_pixels()[:-3]
+    correct_aligned_tree = PixelTree.from_healpix(moc_pixels)
+    moc = correct_aligned_tree.to_moc()
+
+    left_cat_with_moc = Catalog(catalog_info, pixel_tree_2, moc=moc)
+    alignment = left_cat_with_moc.align(right_cat, alignment_type="left")
+    assert_trees_equal(alignment.pixel_tree, correct_aligned_tree)
+    assert_mapping_matches_tree(alignment)
+
+    right_cat_with_moc = Catalog(catalog_info, pixel_tree_3, moc=moc)
+    alignment = left_cat.align(right_cat_with_moc, alignment_type="left")
+    assert_trees_equal(alignment.pixel_tree, aligned_trees_2_3_left)
+    assert_mapping_matches_tree(alignment)
+
+
+def test_catalog_align_right(pixel_tree_2, pixel_tree_3, aligned_trees_2_3_right, catalog_info):
+    left_cat = Catalog(catalog_info, pixel_tree_2)
+    right_cat = Catalog(catalog_info, pixel_tree_3)
+    alignment = left_cat.align(right_cat, alignment_type="right")
+    assert_trees_equal(alignment.pixel_tree, aligned_trees_2_3_right)
+    assert_mapping_matches_tree(alignment)
+
+    moc_pixels = aligned_trees_2_3_right.get_healpix_pixels()[:-3]
+    correct_aligned_tree = PixelTree.from_healpix(moc_pixels)
+    moc = correct_aligned_tree.to_moc()
+
+    left_cat_with_moc = Catalog(catalog_info, pixel_tree_2, moc=moc)
+    alignment = left_cat_with_moc.align(right_cat, alignment_type="right")
+    assert_trees_equal(alignment.pixel_tree, aligned_trees_2_3_right)
+    assert_mapping_matches_tree(alignment)
+
+    right_cat_with_moc = Catalog(catalog_info, pixel_tree_3, moc=moc)
+    alignment = left_cat.align(right_cat_with_moc, alignment_type="right")
+    assert_trees_equal(alignment.pixel_tree, correct_aligned_tree)
+    assert_mapping_matches_tree(alignment)
+
+
+def test_catalog_align_outer(pixel_tree_2, pixel_tree_3, aligned_trees_2_3_outer, catalog_info):
+    left_cat = Catalog(catalog_info, pixel_tree_2)
+    right_cat = Catalog(catalog_info, pixel_tree_3)
+    alignment = left_cat.align(right_cat, alignment_type="outer")
+    assert_trees_equal(alignment.pixel_tree, aligned_trees_2_3_outer)
+    assert_mapping_matches_tree(alignment)
+
+    moc_pixels = aligned_trees_2_3_outer.get_healpix_pixels()[:-3]
+    moc = PixelTree.from_healpix(moc_pixels).to_moc()
+
+    left_moc_correct_tree = PixelTree.from_healpix(moc_pixels + [HealpixPixel(1, 46), HealpixPixel(1, 47)])
+    left_cat_with_moc = Catalog(catalog_info, pixel_tree_2, moc=moc)
+    alignment = left_cat_with_moc.align(right_cat, alignment_type="outer")
+    assert_trees_equal(alignment.pixel_tree, left_moc_correct_tree)
+    assert_mapping_matches_tree(alignment)
+
+    right_moc_correct_tree = PixelTree.from_healpix(moc_pixels + [HealpixPixel(1, 45), HealpixPixel(1, 46)])
+    right_cat_with_moc = Catalog(catalog_info, pixel_tree_3, moc=moc)
+    alignment = left_cat.align(right_cat_with_moc, alignment_type="outer")
+    assert_trees_equal(alignment.pixel_tree, right_moc_correct_tree)
+    assert_mapping_matches_tree(alignment)
+
+    both_moc_correct_tree = PixelTree.from_healpix(moc_pixels)
+    alignment = left_cat_with_moc.align(right_cat_with_moc, alignment_type="outer")
+    assert_trees_equal(alignment.pixel_tree, both_moc_correct_tree)
+    assert_mapping_matches_tree(alignment)

--- a/tests/hipscat/pixel_tree/test_pixel_tree.py
+++ b/tests/hipscat/pixel_tree/test_pixel_tree.py
@@ -15,6 +15,10 @@ def test_pixel_tree_length():
             assert len(tree) == length
 
 
+def test_get_healpix_pixels(pixel_tree_2, pixel_tree_2_pixels):
+    assert pixel_tree_2.get_healpix_pixels() == pixel_tree_2_pixels
+
+
 def test_pixel_tree_max_depth(pixel_tree_1, pixel_tree_2, pixel_tree_3):
     assert pixel_tree_1.get_max_depth() == 0
     assert pixel_tree_2.get_max_depth() == 2

--- a/tests/hipscat/pixel_tree/test_pixel_tree.py
+++ b/tests/hipscat/pixel_tree/test_pixel_tree.py
@@ -1,4 +1,7 @@
+import numpy as np
+
 from hipscat.pixel_math import HealpixPixel
+from hipscat.pixel_math.healpix_pixel import get_higher_order_pixels
 from hipscat.pixel_tree.pixel_tree import PixelTree
 
 
@@ -22,7 +25,18 @@ def test_pixel_tree_different_tree_order(pixel_tree_2):
     pixel_tree_2_order_5 = PixelTree.from_healpix(pixel_tree_2.get_healpix_pixels(), tree_order=5)
     assert pixel_tree_2_order_5.get_max_depth() == 2
     assert pixel_tree_2_order_5.tree_order == 5
-    assert all(pixel_tree_2_order_5.get_healpix_pixels() == pixel_tree_2.get_healpix_pixels())
+    assert pixel_tree_2_order_5.get_healpix_pixels() == pixel_tree_2.get_healpix_pixels()
+
+
+def test_pixel_tree_to_moc(pixel_tree_2):
+    moc = pixel_tree_2.to_moc()
+    moc_order_pixels = np.concatenate(
+        [
+            get_higher_order_pixels(pixel.order, pixel.pixel, moc.max_order - pixel.order)
+            for pixel in pixel_tree_2.get_healpix_pixels()
+        ]
+    )
+    assert np.all(moc.flatten() == moc_order_pixels)
 
 
 def test_pixel_tree_contains():


### PR DESCRIPTION
- Adds functionality to filter a pixel tree by a MOC
- Adds an alignment method which aligns two pairs of pixel trees and uses their MOCs to filter to the pixels that match the higher order coverage
- Adds an `align` function to catalogs to perform an alignment using their pixel trees and MOCs if available
- Adds `to_moc` function to convert a pixel tree to a MOC