### PR TITLE
Fix infinite loop in outer alignment edge case

### DIFF
--- a/src/hipscat/pixel_tree/pixel_alignment.py
+++ b/src/hipscat/pixel_tree/pixel_alignment.py
@@ -237,9 +237,11 @@ def _add_pixels_until(
     """
     while add_from < add_to:
         # maximum power of 4 that is a factor of add_from
-        max_p4_from = add_from & -add_from
-        if max_p4_from & 0xAAAAAAAAAAAAAAA:
-            max_p4_from = max_p4_from >> 1
+        max_p4_from = 64
+        if add_from != 0:
+            max_p4_from = add_from & -add_from
+            if max_p4_from & 0xAAAAAAAAAAAAAAA:
+                max_p4_from = max_p4_from >> 1
 
         # maximum power of 4 less than or equal to (add_to - add_from)
         max_p4_to_log2 = np.int64(np.log2(add_to - add_from))

--- a/src/hipscat/pixel_tree/pixel_alignment.py
+++ b/src/hipscat/pixel_tree/pixel_alignment.py
@@ -236,7 +236,7 @@ def _add_pixels_until(
         mapping (List[np.ndarray]): The List mapping left, right, and aligned pixels to add the new pixels to
     """
     while add_from < add_to:
-        # maximum power of 4 that is a factor of add_from
+        # maximum power of 4 that is a factor of add_from. If add_from is 0, can add any pixel size
         max_p4_from = 64
         if add_from != 0:
             max_p4_from = add_from & -add_from

--- a/src/hipscat/pixel_tree/pixel_alignment.py
+++ b/src/hipscat/pixel_tree/pixel_alignment.py
@@ -236,8 +236,9 @@ def _add_pixels_until(
         mapping (List[np.ndarray]): The List mapping left, right, and aligned pixels to add the new pixels to
     """
     while add_from < add_to:
-        # maximum power of 4 that is a factor of add_from. If add_from is 0, can add any pixel size
-        max_p4_from = 64
+        # maximum power of 4 that is a factor of add_from
+        # If add_from is 0, can add any power of 4, so use largest healpix order of 4**29
+        max_p4_from = 1 << 58
         if add_from != 0:
             max_p4_from = add_from & -add_from
             if max_p4_from & 0xAAAAAAAAAAAAAAA:

--- a/tests/hipscat/pixel_tree/test_pixel_alignment.py
+++ b/tests/hipscat/pixel_tree/test_pixel_alignment.py
@@ -242,3 +242,14 @@ def test_catalog_align_outer(pixel_tree_2, pixel_tree_3, aligned_trees_2_3_outer
     alignment = left_cat_with_moc.align(right_cat_with_moc, alignment_type="outer")
     assert_trees_equal(alignment.pixel_tree, both_moc_correct_tree)
     assert_mapping_matches_tree(alignment)
+
+
+def test_outer_align_start_0():
+    left_tree = PixelTree.from_healpix([HealpixPixel(0, 0)])
+    right_tree = PixelTree.from_healpix([HealpixPixel(1, 1)])
+    alignment = align_trees(left_tree, right_tree, alignment_type="outer")
+    expected_tree = PixelTree.from_healpix(
+        [HealpixPixel(1, 0), HealpixPixel(1, 1), HealpixPixel(1, 2), HealpixPixel(1, 3)]
+    )
+    assert_trees_equal(alignment.pixel_tree, expected_tree)
+    assert_mapping_matches_tree(alignment)


### PR DESCRIPTION
Fixes case where adding new pixels gets pixel size zero when adding new pixels from pixel number 0. This happened when there was an order mismatch with one catalog missing pixel 0 and another catalog having a pixel at 0. Fixes astronomy-commons/lsdb#319