### PR TITLE
Try out py311 for pre-commit CI

### DIFF
--- a/.github/workflows/pre-commit-ci.yml
+++ b/.github/workflows/pre-commit-ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
Seeing some local failures with python 3.9 and 3.11. This just tries out CI with pre-commit in python 3.11.