### PR TITLE
Add dtypes to `HipscatEncoder`

### DIFF
--- a/src/hipscat/io/write_metadata.py
+++ b/src/hipscat/io/write_metadata.py
@@ -24,6 +24,8 @@ class HipscatEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, Path):
             return str(o)
+        if isinstance(o, (type, np.dtype, pd.core.dtypes.base.ExtensionDtype)):
+            return str(o)
         return super().default(o)  # pragma: no cover
 
 

--- a/tests/hipscat/io/test_write_metadata.py
+++ b/tests/hipscat/io/test_write_metadata.py
@@ -27,6 +27,7 @@ def test_write_json_file(assert_text_file_matches, tmp_path):
         "        3,",
         "        5",
         "    ]",
+        r'    "integer_type": "<class \'int\'>"',
         "}",
     ]
 
@@ -35,6 +36,7 @@ def test_write_json_file(assert_text_file_matches, tmp_path):
     dictionary["first_greek"] = "alpha"
     dictionary["first_number"] = 1
     dictionary["first_five_fib"] = [1, 1, 2, 3, 5]
+    dictionary["integer_type"] = int
 
     json_filename = os.path.join(tmp_path, "dictionary.json")
     io.write_json_file(dictionary, json_filename)


### PR DESCRIPTION
Needed for astronomy-commons/hipscat-import#316

## Change Description

Adds functionality to convert relevant types to strings for json serialization.

astronomy-commons/hipscat-import#316 updates the file readers to return provenance info that includes all class attributes. It picks up attributes that were not previously being captured and results in some tests failing when the values cannot be json serialized. As far as I can tell, the best place to handle this is here, in `hipscat.io.write_metadata.HipscatEncoder`.

- [x] My PR includes a link to the issue that I am addressing

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [ ] My code builds (or compiles) cleanly without any errors or warnings
- [ ] My code contains relevant comments and necessary documentation

### New Feature Checklist
- [ ] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
