### PR TITLE
Pin matplotlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "astropy",
     "fsspec>=2023.10.0", # Used for abstract filesystems
     "healpy",
+    "matplotlib>=3.3,<3.9",
     "mocpy",
     "numba>=0.58",
     "numpy", 


### PR DESCRIPTION
## Change Description

matplotlib has deprecated `get_cmap` (which they've been warning about). Healpy uses this method internally when creating a mollweide plot (and other plotting styles).

This pins matplotlib to an earlier version until healpy can be updated (or we can remove our dependency on `healpy.visufunc`

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation