### PR TITLE
Add catalog filter_by_moc method and replace spatial filters to use it

### DIFF
--- a/src/.pylintrc
+++ b/src/.pylintrc
@@ -62,7 +62,7 @@ ignore-patterns=_version.py
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis). It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=astropy.units
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().

--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -122,9 +122,11 @@ class Catalog(HealpixDataset):
             validate_declination_values(dec)
             # Get the coordinates vector on the unit sphere if we were provided
             # with polygon spherical coordinates of ra and dec
-            vertices = hp.ang2vec(ra, dec, lonlat=True)
-        validate_polygon(vertices)
-        return self.filter_from_pixel_list(filter_pixels_by_polygon(self.pixel_tree, vertices))
+            cart_vertices = hp.ang2vec(ra, dec, lonlat=True)
+        else:
+            cart_vertices = vertices
+        validate_polygon(cart_vertices)
+        return self.filter_from_pixel_list(filter_pixels_by_polygon(self.pixel_tree, cart_vertices))
 
     def generate_negative_tree_pixels(self) -> List[HealpixPixel]:
         """Get the leaf nodes at each healpix order that have zero catalog data.

--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -13,13 +13,9 @@ from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.catalog.catalog_type import CatalogType
 from hipscat.catalog.healpix_dataset.healpix_dataset import HealpixDataset, PixelInputTypes
 from hipscat.pixel_math import HealpixPixel
-from hipscat.pixel_math.box_filter import wrap_ra_angles, generate_box_moc
+from hipscat.pixel_math.box_filter import generate_box_moc, wrap_ra_angles
 from hipscat.pixel_math.cone_filter import generate_cone_moc
-from hipscat.pixel_math.polygon_filter import (
-    CartesianCoordinates,
-    SphericalCoordinates,
-    generate_polygon_moc,
-)
+from hipscat.pixel_math.polygon_filter import CartesianCoordinates, SphericalCoordinates, generate_polygon_moc
 from hipscat.pixel_math.validators import (
     validate_box_search,
     validate_declination_values,

--- a/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
@@ -133,6 +133,8 @@ class HealpixDataset(Dataset):
             )
 
     def get_max_coverage_order(self):
+        """Gets the maximum HEALPix order for which the coverage of the catalog is known from the pixel
+        tree and moc if it exists"""
         max_order = (
             max(self.moc.max_order, self.pixel_tree.get_max_depth())
             if self.moc is not None
@@ -141,14 +143,14 @@ class HealpixDataset(Dataset):
         return max_order
 
     def filter_from_pixel_list(self, pixels: List[HealpixPixel]) -> Self:
-        """Filter the pixels in the catalog to only include the requested pixels.
+        """Filter the pixels in the catalog to only include any that overlap with the requested pixels.
 
         Args:
             pixels (List[HealpixPixels]): the pixels to include
 
         Returns:
-            A new catalog with only those pixels. Note that we reset the total_rows
-            to None, instead of performing a scan over the new pixel sizes.
+            A new catalog with only the pixels that overlap with the given pixels. Note that we reset the
+            total_rows to None, as updating would require a scan over the new pixel sizes.
         """
         orders = np.array([p.order for p in pixels])
         pixel_inds = np.array([p.pixel for p in pixels])
@@ -157,6 +159,14 @@ class HealpixDataset(Dataset):
         return self.filter_by_moc(moc)
 
     def filter_by_moc(self, moc: MOC) -> Self:
+        """Filter the pixels in the catalog to only include the pixels that overlap with the moc provided.
+
+        Args:
+            moc (mocpy.MOC): the moc to filter by
+
+        Returns:
+            A new catalog with only the pixels that overlap with the moc. Note that we reset the total_rows
+            to None, as updating would require a scan over the new pixel sizes."""
         filtered_tree = filter_by_moc(self.pixel_tree, moc)
         filtered_moc = self.moc.intersection(moc) if self.moc is not None else None
         filtered_catalog_info = dataclasses.replace(self.catalog_info, total_rows=None)

--- a/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
@@ -14,6 +14,7 @@ from hipscat.catalog.partition_info import PartitionInfo
 from hipscat.io import FilePointer, file_io, paths
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_tree import PixelAlignment, PixelAlignmentType
+from hipscat.pixel_tree.moc_filter import filter_by_moc
 from hipscat.pixel_tree.pixel_alignment import align_with_mocs
 from hipscat.pixel_tree.pixel_tree import PixelTree
 
@@ -141,8 +142,17 @@ class HealpixDataset(Dataset):
             A new catalog with only those pixels. Note that we reset the total_rows
             to None, instead of performing a scan over the new pixel sizes.
         """
+        orders = np.array([p.order for p in pixels])
+        pixel_inds = np.array([p.pixel for p in pixels])
+        max_order = np.max(orders) if len(orders) > 0 else 0
+        moc = MOC.from_healpix_cells(ipix=pixel_inds, depth=orders, max_depth=max_order)
+        return self.filter_by_moc(moc)
+
+    def filter_by_moc(self, moc: MOC) -> Self:
+        filtered_tree = filter_by_moc(self.pixel_tree, moc)
+        filtered_moc = self.moc.intersection(moc) if self.moc is not None else None
         filtered_catalog_info = dataclasses.replace(self.catalog_info, total_rows=None)
-        return self.__class__(filtered_catalog_info, pixels)
+        return self.__class__(filtered_catalog_info, filtered_tree, moc=filtered_moc)
 
     def align(
         self, other_cat: Self, alignment_type: PixelAlignmentType = PixelAlignmentType.INNER

--- a/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
@@ -132,6 +132,14 @@ class HealpixDataset(Dataset):
                 f"_metadata or partition info file is required in catalog directory {catalog_base_dir}"
             )
 
+    def get_max_coverage_order(self):
+        max_order = (
+            max(self.moc.max_order, self.pixel_tree.get_max_depth())
+            if self.moc is not None
+            else self.pixel_tree.get_max_depth()
+        )
+        return max_order
+
     def filter_from_pixel_list(self, pixels: List[HealpixPixel]) -> Self:
         """Filter the pixels in the catalog to only include the requested pixels.
 

--- a/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
@@ -132,7 +132,7 @@ class HealpixDataset(Dataset):
                 f"_metadata or partition info file is required in catalog directory {catalog_base_dir}"
             )
 
-    def get_max_coverage_order(self):
+    def get_max_coverage_order(self) -> int:
         """Gets the maximum HEALPix order for which the coverage of the catalog is known from the pixel
         tree and moc if it exists"""
         max_order = (

--- a/src/hipscat/catalog/margin_cache/margin_catalog.py
+++ b/src/hipscat/catalog/margin_cache/margin_catalog.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from mocpy import MOC
-from typing_extensions import TypeAlias, Self
 import healpy as hp
+from mocpy import MOC
+from typing_extensions import Self, TypeAlias
 
 from hipscat.catalog.catalog_type import CatalogType
 from hipscat.catalog.healpix_dataset.healpix_dataset import HealpixDataset, PixelInputTypes

--- a/src/hipscat/catalog/margin_cache/margin_catalog.py
+++ b/src/hipscat/catalog/margin_cache/margin_catalog.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from mocpy import MOC
-from typing_extensions import TypeAlias
+from typing_extensions import TypeAlias, Self
+import healpy as hp
 
 from hipscat.catalog.catalog_type import CatalogType
 from hipscat.catalog.healpix_dataset.healpix_dataset import HealpixDataset, PixelInputTypes
 from hipscat.catalog.margin_cache import MarginCacheCatalogInfo
+from hipscat.pixel_tree.moc_utils import copy_moc
 
 
 class MarginCatalog(HealpixDataset):
@@ -46,3 +48,14 @@ class MarginCatalog(HealpixDataset):
         super().__init__(
             catalog_info, pixels, catalog_path=catalog_path, moc=moc, storage_options=storage_options
         )
+
+    def filter_by_moc(self, moc: MOC) -> Self:
+        max_order = self.pixel_tree.get_max_depth()
+        max_order_size = hp.nside2resol(2**max_order, arcmin=True)
+        if self.catalog_info.margin_threshold > max_order_size * 60:
+            raise ValueError(
+                f"Cannot Filter Margin: Margin size {self.catalog_info.margin_threshold} is "
+                f"greater than the size of a pixel at the highest order {max_order}."
+            )
+        search_moc = copy_moc(moc).add_neighbours()
+        return super().filter_by_moc(search_moc)

--- a/src/hipscat/catalog/margin_cache/margin_catalog.py
+++ b/src/hipscat/catalog/margin_cache/margin_catalog.py
@@ -50,7 +50,20 @@ class MarginCatalog(HealpixDataset):
         )
 
     def filter_by_moc(self, moc: MOC) -> Self:
-        max_order = self.pixel_tree.get_max_depth()
+        """Filter the pixels in the margin catalog to only include the margin pixels that overlap with the moc
+
+        For the case of margin pixels, this includes any pixels whose margin areas may overlap with the moc.
+        This is not always done with a high accuracy, but always includes any pixels that will overlap,
+        and may include extra partitions that do not.
+
+        Args:
+            moc (mocpy.MOC): the moc to filter by
+
+        Returns:
+            A new margin catalog with only the pixels that overlap or that have margin area that overlap with
+            the moc. Note that we reset the total_rows to None, as updating would require a scan over the new
+            pixel sizes."""
+        max_order = moc.max_order
         max_order_size = hp.nside2resol(2**max_order, arcmin=True)
         if self.catalog_info.margin_threshold > max_order_size * 60:
             raise ValueError(

--- a/src/hipscat/pixel_math/box_filter.py
+++ b/src/hipscat/pixel_math/box_filter.py
@@ -7,7 +7,6 @@ import numpy as np
 from mocpy import MOC
 
 from hipscat.pixel_math.polygon_filter import SphericalCoordinates
-from hipscat.pixel_tree.pixel_tree import PixelTree
 
 
 def generate_box_moc(ra: Tuple[float, float], dec: Tuple[float, float], order: int) -> MOC:

--- a/src/hipscat/pixel_math/box_filter.py
+++ b/src/hipscat/pixel_math/box_filter.py
@@ -12,29 +12,6 @@ from hipscat.pixel_tree.moc_filter import filter_by_moc
 from hipscat.pixel_tree.pixel_tree import PixelTree
 
 
-def filter_pixels_by_box(
-    pixel_tree: PixelTree, ra: Tuple[float, float] | None, dec: Tuple[float, float] | None
-) -> List[HealpixPixel]:
-    """Filter the leaf pixels in a pixel tree to return a partition_info dataframe
-    with the pixels that overlap with a right ascension and/or declination region.
-
-    Args:
-        pixel_tree (PixelTree): The catalog tree to filter pixels from
-        ra (Tuple[float, float]): Right ascension range, in [0,360] degrees
-        dec (Tuple[float, float]): Declination range, in [-90,90] degrees
-
-    Returns:
-        List of HEALPix representing only the pixels that overlap with the right
-        ascension and/or declination region.
-    """
-    max_order = pixel_tree.get_max_depth()
-    search_moc = generate_box_moc(ra, dec, max_order)
-
-    result_pixels = filter_by_moc(pixel_tree, search_moc).get_healpix_pixels()
-
-    return result_pixels
-
-
 def generate_box_moc(ra, dec, order):
     filter_moc = None
     ra_search_moc, dec_search_moc = None, None

--- a/src/hipscat/pixel_math/box_filter.py
+++ b/src/hipscat/pixel_math/box_filter.py
@@ -6,13 +6,21 @@ import healpy as hp
 import numpy as np
 from mocpy import MOC
 
-from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.polygon_filter import SphericalCoordinates
-from hipscat.pixel_tree.moc_filter import filter_by_moc
 from hipscat.pixel_tree.pixel_tree import PixelTree
 
 
-def generate_box_moc(ra, dec, order):
+def generate_box_moc(ra: Tuple[float, float], dec: Tuple[float, float], order: int) -> MOC:
+    """Generates a MOC object that covers the specified box area
+
+    Args:
+        ra (Tuple[float, float]): Right ascension range, in [0,360] degrees
+        dec (Tuple[float, float]): Declination range, in [-90,90] degrees
+        order (int): Maximum order of the moc to generate the box at
+
+    Returns:
+        a MOC object that covers the specified box
+    """
     filter_moc = None
     ra_search_moc, dec_search_moc = None, None
 

--- a/src/hipscat/pixel_math/box_filter.py
+++ b/src/hipscat/pixel_math/box_filter.py
@@ -81,7 +81,7 @@ def _generate_ra_strip_moc(ra_range: Tuple[float, float], order: int) -> MOC:
     return MOC.from_healpix_cells(ipix=pixels_in_range, depth=orders, max_depth=order)
 
 
-def _generate_dec_strip_moc(dec_range: Tuple[float, float], order: int) -> PixelTree:
+def _generate_dec_strip_moc(dec_range: Tuple[float, float], order: int) -> MOC:
     """Generates a pixel_tree filled with leaf nodes at a given order that overlap with the dec region."""
     nside = hp.order2nside(order)
     # Convert declination values to colatitudes, in radians, and revert their order

--- a/src/hipscat/pixel_math/cone_filter.py
+++ b/src/hipscat/pixel_math/cone_filter.py
@@ -1,11 +1,5 @@
-from typing import List
-
-from mocpy import MOC
 import astropy.units as u
-
-from hipscat.pixel_math import HealpixPixel
-from hipscat.pixel_tree.moc_filter import filter_by_moc
-from hipscat.pixel_tree.pixel_tree import PixelTree
+from mocpy import MOC
 
 
 def generate_cone_moc(ra: float, dec: float, radius_arcsec: float, order: int) -> MOC:

--- a/src/hipscat/pixel_math/cone_filter.py
+++ b/src/hipscat/pixel_math/cone_filter.py
@@ -1,10 +1,10 @@
 from typing import List
 
-import healpy as hp
-import numpy as np
+from mocpy import MOC
+import astropy.units as u
 
 from hipscat.pixel_math import HealpixPixel
-from hipscat.pixel_math.filter import get_filtered_pixel_list
+from hipscat.pixel_tree.moc_filter import filter_by_moc
 from hipscat.pixel_tree.pixel_tree import PixelTree
 
 
@@ -23,15 +23,10 @@ def filter_pixels_by_cone(
         List of HealpixPixels representing only the pixels that overlap with the specified cone.
     """
     max_order = pixel_tree.get_max_depth()
-    cone_tree = _generate_cone_pixel_tree(ra, dec, radius_arcsec, max_order)
-    return get_filtered_pixel_list(pixel_tree, cone_tree)
+    cone_moc = generate_cone_moc(ra, dec, radius_arcsec, max_order)
+    return filter_by_moc(pixel_tree, cone_moc).get_healpix_pixels()
 
 
-def _generate_cone_pixel_tree(ra: float, dec: float, radius_arcsec: float, order: int):
-    """Generates a pixel_tree filled with leaf nodes at a given order that overlap with a cone"""
-    n_side = hp.order2nside(order)
-    center_vec = hp.ang2vec(ra, dec, lonlat=True)
-    radius_radians = np.radians(radius_arcsec / 3600.0)
-    cone_pixels = hp.query_disc(n_side, center_vec, radius_radians, inclusive=True, nest=True)
-    pixel_list = [HealpixPixel(order, cone_pixel) for cone_pixel in cone_pixels]
-    return PixelTree.from_healpix(pixel_list)
+def generate_cone_moc(ra: float, dec: float, radius_arcsec: float, order: int) -> MOC:
+    """Generate a MOC object that covers the cone"""
+    return MOC.from_cone(lon=ra * u.deg, lat=dec * u.deg, radius=radius_arcsec * u.arcsec, max_depth=order)

--- a/src/hipscat/pixel_math/cone_filter.py
+++ b/src/hipscat/pixel_math/cone_filter.py
@@ -8,25 +8,6 @@ from hipscat.pixel_tree.moc_filter import filter_by_moc
 from hipscat.pixel_tree.pixel_tree import PixelTree
 
 
-def filter_pixels_by_cone(
-    pixel_tree: PixelTree, ra: float, dec: float, radius_arcsec: float
-) -> List[HealpixPixel]:
-    """Filter the leaf pixels in a pixel tree to return a partition_info dataframe with the pixels
-    that overlap with a cone.
-
-    Args:
-        ra (float): Right Ascension of the center of the cone in degrees
-        dec (float): Declination of the center of the cone in degrees
-        radius_arcsec (float): Radius of the cone in arcseconds
-
-    Returns:
-        List of HealpixPixels representing only the pixels that overlap with the specified cone.
-    """
-    max_order = pixel_tree.get_max_depth()
-    cone_moc = generate_cone_moc(ra, dec, radius_arcsec, max_order)
-    return filter_by_moc(pixel_tree, cone_moc).get_healpix_pixels()
-
-
 def generate_cone_moc(ra: float, dec: float, radius_arcsec: float, order: int) -> MOC:
     """Generate a MOC object that covers the cone"""
     return MOC.from_cone(lon=ra * u.deg, lat=dec * u.deg, radius=radius_arcsec * u.arcsec, max_depth=order)

--- a/src/hipscat/pixel_math/polygon_filter.py
+++ b/src/hipscat/pixel_math/polygon_filter.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import Tuple
 
 import healpy as hp
 import numpy as np
 from mocpy import MOC
 from typing_extensions import TypeAlias
-
-from hipscat.pixel_math import HealpixPixel
-from hipscat.pixel_tree.moc_filter import filter_by_moc
-from hipscat.pixel_tree.pixel_tree import PixelTree
 
 # Pair of spherical sky coordinates (ra, dec)
 SphericalCoordinates: TypeAlias = Tuple[float, float]

--- a/src/hipscat/pixel_math/polygon_filter.py
+++ b/src/hipscat/pixel_math/polygon_filter.py
@@ -7,8 +7,6 @@ import numpy as np
 from mocpy import MOC
 from typing_extensions import TypeAlias
 
-import astropy.units as u
-
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_tree.moc_filter import filter_by_moc
 from hipscat.pixel_tree.pixel_tree import PixelTree
@@ -18,27 +16,6 @@ SphericalCoordinates: TypeAlias = Tuple[float, float]
 
 # Sky coordinates on the unit sphere, in cartesian representation (x,y,z)
 CartesianCoordinates: TypeAlias = Tuple[float, float, float]
-
-
-def filter_pixels_by_polygon(
-    pixel_tree: PixelTree, vertices: List[CartesianCoordinates]
-) -> List[HealpixPixel]:
-    """Filter the leaf pixels in a pixel tree to return a list of healpix pixels that
-    overlap with a polygonal region.
-
-    Args:
-        pixel_tree (PixelTree): The catalog tree to filter pixels from.
-        vertices (List[CartesianCoordinates]): The vertices of the polygon to filter points
-            with, in lists of (x,y,z) points on the unit sphere.
-
-    Returns:
-        List of HealpixPixel, representing only the pixels that overlap
-        with the specified polygonal region, and the maximum pixel order.
-    """
-    vertices = np.array(vertices)
-    max_order = pixel_tree.get_max_depth()
-    polygon_moc = generate_polygon_moc(vertices, max_order)
-    return filter_by_moc(pixel_tree, polygon_moc).get_healpix_pixels()
 
 
 def generate_polygon_moc(vertices: np.array, order: int) -> MOC:

--- a/src/hipscat/pixel_math/polygon_filter.py
+++ b/src/hipscat/pixel_math/polygon_filter.py
@@ -16,8 +16,8 @@ CartesianCoordinates: TypeAlias = Tuple[float, float, float]
 
 def generate_polygon_moc(vertices: np.array, order: int) -> MOC:
     """Generates a moc filled with leaf nodes at a given order that overlap within
-    a polygon. Vertices is an array of Spherical coordinates, in representation (ra,dec)
-    and shape (Num vertices, 2), representing the vertices of the polygon."""
+    a polygon. Vertices is an array of cartesian coordinates, in representation (x,y,z)
+    and shape (Num vertices, 3), representing the vertices of the polygon."""
     polygon_pixels = hp.query_polygon(hp.order2nside(order), vertices, inclusive=True, nest=True)
     polygon_orders = np.full(len(polygon_pixels), fill_value=order)
     return MOC.from_healpix_cells(ipix=polygon_pixels, depth=polygon_orders, max_depth=order)

--- a/src/hipscat/pixel_tree/moc_utils.py
+++ b/src/hipscat/pixel_tree/moc_utils.py
@@ -2,4 +2,5 @@ from mocpy import MOC
 
 
 def copy_moc(moc: MOC) -> MOC:
+    """Returns a copy of a given MOC object"""
     return MOC.from_depth29_ranges(max_depth=moc.max_order, ranges=moc.to_depth29_ranges)

--- a/src/hipscat/pixel_tree/moc_utils.py
+++ b/src/hipscat/pixel_tree/moc_utils.py
@@ -1,0 +1,5 @@
+from mocpy import MOC
+
+
+def copy_moc(moc: MOC) -> MOC:
+    return MOC.from_depth29_ranges(max_depth=moc.max_order, ranges=moc.to_depth29_ranges)

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -62,7 +62,7 @@ ignore-patterns=_version.py
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis). It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=astropy.units
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().

--- a/tests/hipscat/catalog/margin_cache/test_margin_catalog.py
+++ b/tests/hipscat/catalog/margin_cache/test_margin_catalog.py
@@ -89,3 +89,11 @@ def test_margin_filter(margin_catalog_info, margin_catalog_pixels):
         HealpixPixel(1, 46),
         HealpixPixel(1, 47),
     ]
+
+
+def test_margin_filter_invalid_size(margin_catalog_info, margin_catalog_pixels):
+    margin_catalog_info.margin_threshold = 10000000
+    catalog = MarginCatalog(margin_catalog_info, margin_catalog_pixels)
+    pixels = [HealpixPixel(1, 44)]
+    with pytest.raises(ValueError, match="greater than the size of a pixel"):
+        catalog.filter_from_pixel_list(pixels)

--- a/tests/hipscat/catalog/margin_cache/test_margin_catalog.py
+++ b/tests/hipscat/catalog/margin_cache/test_margin_catalog.py
@@ -5,6 +5,7 @@ import pytest
 
 from hipscat.catalog import CatalogType, MarginCatalog, PartitionInfo
 from hipscat.loaders import read_from_hipscat
+from hipscat.pixel_math import HealpixPixel
 
 
 def test_init_catalog(margin_catalog_info, margin_catalog_pixels):
@@ -76,3 +77,15 @@ def test_empty_directory(tmp_path, margin_cache_catalog_info_data, margin_catalo
     with pytest.warns(UserWarning, match="slow"):
         catalog = read_from_hipscat(catalog_path)
     assert catalog.catalog_name == margin_cache_catalog_info_data["catalog_name"]
+
+
+def test_margin_filter(margin_catalog_info, margin_catalog_pixels):
+    catalog = MarginCatalog(margin_catalog_info, margin_catalog_pixels)
+    pixels = [HealpixPixel(1, 44)]
+    filtered_catalog = catalog.filter_from_pixel_list(pixels)
+    assert filtered_catalog.get_healpix_pixels() == [
+        HealpixPixel(1, 44),
+        HealpixPixel(1, 45),
+        HealpixPixel(1, 46),
+        HealpixPixel(1, 47),
+    ]

--- a/tests/hipscat/catalog/test_catalog.py
+++ b/tests/hipscat/catalog/test_catalog.py
@@ -11,7 +11,7 @@ from hipscat.io import paths
 from hipscat.io.file_io import read_fits_image
 from hipscat.loaders import read_from_hipscat
 from hipscat.pixel_math import HealpixPixel
-from hipscat.pixel_math.box_filter import _generate_ra_strip_pixel_tree
+from hipscat.pixel_math.box_filter import _generate_ra_strip_moc
 from hipscat.pixel_math.validators import ValidatorsErrors
 from hipscat.pixel_tree.pixel_tree import PixelTree
 
@@ -308,25 +308,25 @@ def test_box_filter_ra_divisions_edge_cases(small_sky_order1_catalog):
 def test_box_filter_ra_pixel_tree_generation():
     """This method tests the pixel tree generation for the ra filter"""
     # The catalog pixels are distributed around the [270,0] degree range.
-    pixel_tree = _generate_ra_strip_pixel_tree(ra_range=(0, 180), order=1)
-    pixel_tree_complement = _generate_ra_strip_pixel_tree(ra_range=(180, 0), order=1)
-    assert len(pixel_tree) == len(pixel_tree_complement)
+    moc = _generate_ra_strip_moc(ra_range=(0, 180), order=1)
+    moc_complement = _generate_ra_strip_moc(ra_range=(180, 0), order=1)
+    assert len(moc.flatten()) == len(moc_complement.flatten())
 
-    pixel_tree = _generate_ra_strip_pixel_tree(ra_range=(10, 50), order=1)
-    pixel_tree_complement = _generate_ra_strip_pixel_tree(ra_range=(50, 10), order=1)
-    assert len(pixel_tree) < len(pixel_tree_complement)
+    moc = _generate_ra_strip_moc(ra_range=(10, 50), order=1)
+    moc_complement = _generate_ra_strip_moc(ra_range=(50, 10), order=1)
+    assert len(moc.flatten()) < len(moc_complement.flatten())
 
-    pixel_tree = _generate_ra_strip_pixel_tree(ra_range=(10, 220), order=1)
-    pixel_tree_complement = _generate_ra_strip_pixel_tree(ra_range=(220, 10), order=1)
-    assert len(pixel_tree_complement) < len(pixel_tree)
+    moc = _generate_ra_strip_moc(ra_range=(10, 220), order=1)
+    moc_complement = _generate_ra_strip_moc(ra_range=(220, 10), order=1)
+    assert len(moc_complement.flatten()) < len(moc.flatten())
 
-    pixel_tree = _generate_ra_strip_pixel_tree(ra_range=(200, 350), order=1)
-    pixel_tree_complement = _generate_ra_strip_pixel_tree(ra_range=(350, 200), order=1)
-    assert len(pixel_tree) < len(pixel_tree_complement)
+    moc = _generate_ra_strip_moc(ra_range=(200, 350), order=1)
+    moc_complement = _generate_ra_strip_moc(ra_range=(350, 200), order=1)
+    assert len(moc.flatten()) < len(moc_complement.flatten())
 
-    pixel_tree = _generate_ra_strip_pixel_tree(ra_range=(200, 50), order=1)
-    pixel_tree_complement = _generate_ra_strip_pixel_tree(ra_range=(50, 200), order=1)
-    assert len(pixel_tree_complement) < len(pixel_tree)
+    moc = _generate_ra_strip_moc(ra_range=(200, 50), order=1)
+    moc_complement = _generate_ra_strip_moc(ra_range=(50, 200), order=1)
+    assert len(moc_complement.flatten()) < len(moc.flatten())
 
 
 def test_box_filter_dec(small_sky_order1_catalog):

--- a/tests/hipscat/catalog/test_catalog.py
+++ b/tests/hipscat/catalog/test_catalog.py
@@ -2,9 +2,9 @@
 
 import os
 
+import astropy.units as u
 import healpy as hp
 import numpy as np
-import pandas as pd
 import pytest
 from mocpy import MOC
 
@@ -14,11 +14,8 @@ from hipscat.io.file_io import read_fits_image
 from hipscat.loaders import read_from_hipscat
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.box_filter import _generate_ra_strip_moc, generate_box_moc
-from hipscat.pixel_math.polygon_filter import generate_polygon_moc
 from hipscat.pixel_math.validators import ValidatorsErrors
 from hipscat.pixel_tree.pixel_tree import PixelTree
-
-import astropy.units as u
 
 
 def test_catalog_load(catalog_info, catalog_pixels):

--- a/tests/hipscat/catalog/test_catalog.py
+++ b/tests/hipscat/catalog/test_catalog.py
@@ -283,7 +283,6 @@ def test_polygonal_filter_invalid_polygon(small_sky_order1_catalog):
 
 
 def test_box_filter_ra(small_sky_order1_catalog):
-
     ra = (280, 290)
     # The catalog pixels are distributed around the [270,0] degree range.
     filtered_catalog = small_sky_order1_catalog.filter_by_box(ra=ra)


### PR DESCRIPTION
Adds the `filter_by_moc` method to the `HealpixDataset` class and changes the spatial filter methods to use it. Adds the logic for performing a margin spatial filter to the `MarginCatalog` class.