### PR TITLE
Support more types in json encoding.

### DIFF
--- a/src/hipscat/io/write_metadata.py
+++ b/src/hipscat/io/write_metadata.py
@@ -12,6 +12,7 @@ import pandas as pd
 
 from hipscat.io import file_io, paths
 from hipscat.io.parquet_metadata import write_parquet_metadata as wpm
+from hipscat.pixel_math.healpix_pixel import HealpixPixel
 
 
 class HipscatEncoder(json.JSONEncoder):
@@ -26,6 +27,12 @@ class HipscatEncoder(json.JSONEncoder):
             return str(o)
         if isinstance(o, (type, np.dtype, pd.core.dtypes.base.ExtensionDtype)):
             return str(o)
+        if isinstance(o, HealpixPixel):
+            return str(o)
+        if np.issubdtype(o.dtype, np.integer):
+            return int(o)
+        if isinstance(o, np.ndarray):
+            return o.tolist()
         return super().default(o)  # pragma: no cover
 
 

--- a/tests/hipscat/io/test_write_metadata.py
+++ b/tests/hipscat/io/test_write_metadata.py
@@ -4,6 +4,7 @@ import os
 import shutil
 from pathlib import Path
 
+import numpy as np
 import numpy.testing as npt
 
 import hipscat.io.write_metadata as io
@@ -27,7 +28,14 @@ def test_write_json_file(assert_text_file_matches, tmp_path):
         "        3,",
         "        5",
         "    ]",
-        r'    "integer_type": "<class \'int\'>"',
+        r'    "integer_type": "<class \'int\'>",',
+        '    "np_int": 5000000,',
+        '    "np_float": 1.618,',
+        '    "pixel": "Order: 5, Pixel: 9000",',
+        r'    "pixels": \[',
+        '        "Order: 5, Pixel: 9000",',
+        '        "Order: 5, Pixel: 9001"',
+        "    ]",
         "}",
     ]
 
@@ -37,6 +45,10 @@ def test_write_json_file(assert_text_file_matches, tmp_path):
     dictionary["first_number"] = 1
     dictionary["first_five_fib"] = [1, 1, 2, 3, 5]
     dictionary["integer_type"] = int
+    dictionary["np_int"] = np.uint64(5_000_000)
+    dictionary["np_float"] = np.float64(1.618)
+    dictionary["pixel"] = HealpixPixel(5, 9_000)
+    dictionary["pixels"] = np.array([HealpixPixel(5, 9_000), HealpixPixel(5, 9_001)])
 
     json_filename = os.path.join(tmp_path, "dictionary.json")
     io.write_json_file(dictionary, json_filename)


### PR DESCRIPTION
## Change Description

Pretty-print healpix pixel, using string-ification.

Detect numpy types and convert to regular python types for friendlier printing.

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation