### PR TITLE
Derive `MarginCacheCatalogInfo` from `CatalogInfo`

### DIFF
--- a/src/hipscat/catalog/margin_cache/margin_cache_catalog_info.py
+++ b/src/hipscat/catalog/margin_cache/margin_cache_catalog_info.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 
 from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.catalog.catalog_type import CatalogType
-from hipscat.catalog.dataset.base_catalog_info import BaseCatalogInfo
 
 
 @dataclass
@@ -17,7 +16,7 @@ class MarginCacheCatalogInfo(CatalogInfo):
     margin_threshold: float = None
     """Threshold of the pixel boundary, expressed in arcseconds."""
 
-    required_fields = BaseCatalogInfo.required_fields + [
+    required_fields = CatalogInfo.required_fields + [
         "primary_catalog",
         "margin_threshold",
     ]

--- a/src/hipscat/catalog/margin_cache/margin_cache_catalog_info.py
+++ b/src/hipscat/catalog/margin_cache/margin_cache_catalog_info.py
@@ -2,12 +2,13 @@
 
 from dataclasses import dataclass
 
+from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.catalog.catalog_type import CatalogType
 from hipscat.catalog.dataset.base_catalog_info import BaseCatalogInfo
 
 
 @dataclass
-class MarginCacheCatalogInfo(BaseCatalogInfo):
+class MarginCacheCatalogInfo(CatalogInfo):
     """Catalog Info for a HiPSCat Margin Cache table"""
 
     primary_catalog: str = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,12 +134,14 @@ def source_catalog_info_with_extra() -> dict:
 
 
 @pytest.fixture
-def margin_cache_catalog_info_data(catalog_info_data) -> dict:
+def margin_cache_catalog_info_data() -> dict:
     return {
-        **catalog_info_data,
         "catalog_name": "test_margin",
         "catalog_type": "margin",
         "total_rows": 100,
+        "epoch": "J2000",
+        "ra_column": "ra",
+        "dec_column": "dec",
         "primary_catalog": "test_name",
         "margin_threshold": 0.5,
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,8 +134,9 @@ def source_catalog_info_with_extra() -> dict:
 
 
 @pytest.fixture
-def margin_cache_catalog_info_data() -> dict:
+def margin_cache_catalog_info_data(catalog_info_data) -> dict:
     return {
+        **catalog_info_data,
         "catalog_name": "test_margin",
         "catalog_type": "margin",
         "total_rows": 100,

--- a/tests/data/almanac/small_sky_order1_margin.yml
+++ b/tests/data/almanac/small_sky_order1_margin.yml
@@ -7,6 +7,9 @@ catalog_info:
   catalog_name: small_sky_order1_margin
   catalog_type: margin
   total_rows: 28
+  epoch: J2000
+  ra_column: ra
+  dec_column: dec
   primary_catalog: small_sky_order1
   margin_threshold: 7200
 primary: small_sky_order1

--- a/tests/data/almanac_exception/margin_missing_primary.yml
+++ b/tests/data/almanac_exception/margin_missing_primary.yml
@@ -5,5 +5,8 @@ catalog_info:
   catalog_name: margin_cache
   catalog_type: margin
   total_rows: 100
+  epoch: J2000
+  ra_column: ra
+  dec_column: dec
   primary_catalog: NOT_A_CATALOG
   margin_threshold: 0.5

--- a/tests/data/info_only/margin_cache/catalog_info.json
+++ b/tests/data/info_only/margin_cache/catalog_info.json
@@ -2,6 +2,9 @@
   "catalog_name": "margin_cache",
   "catalog_type": "margin",
   "total_rows": 100,
+  "epoch": "J2000",
+  "ra_column": "ra",
+  "dec_column": "dec",
   "primary_catalog": "catalog",
   "margin_threshold": 0.5
 }

--- a/tests/data/small_sky_order1_margin/catalog_info.json
+++ b/tests/data/small_sky_order1_margin/catalog_info.json
@@ -2,6 +2,9 @@
     "catalog_name": "small_sky_order1_margin",
     "catalog_type": "margin",
     "total_rows": 28,
+    "epoch": "J2000",
+    "ra_column": "ra",
+    "dec_column": "dec",
     "primary_catalog": "small_sky_order1",
     "margin_threshold": 7200
 }

--- a/tests/hipscat/catalog/margin_cache/test_margin_cache_catalog_info.py
+++ b/tests/hipscat/catalog/margin_cache/test_margin_cache_catalog_info.py
@@ -58,7 +58,8 @@ def test_type_missing(margin_cache_catalog_info_data):
 
 def test_wrong_type(margin_cache_catalog_info_data, catalog_info_data):
     with pytest.raises(TypeError, match="unexpected"):
-        MarginCacheCatalogInfo(**catalog_info_data)
+        unexpected_info = {**catalog_info_data, "invalid_key": "unknown"}
+        MarginCacheCatalogInfo(**unexpected_info)
 
     with pytest.raises(ValueError, match=f"{CatalogType.MARGIN}"):
         init_data = margin_cache_catalog_info_data.copy()

--- a/tests/hipscat/catalog/margin_cache/test_margin_cache_catalog_info.py
+++ b/tests/hipscat/catalog/margin_cache/test_margin_cache_catalog_info.py
@@ -28,6 +28,9 @@ def test_read_from_file(margin_cache_catalog_info_file, assert_catalog_info_matc
         "catalog_name",
         "catalog_type",
         "total_rows",
+        "epoch",
+        "ra_column",
+        "dec_column",
         "primary_catalog",
         "margin_threshold",
     ]:

--- a/tests/hipscat/catalog/margin_cache/test_margin_catalog.py
+++ b/tests/hipscat/catalog/margin_cache/test_margin_catalog.py
@@ -44,6 +44,9 @@ def test_read_from_file(margin_catalog_path, margin_catalog_pixels):
     info = catalog.catalog_info
     assert info.catalog_name == "small_sky_order1_margin"
     assert info.catalog_type == CatalogType.MARGIN
+    assert info.epoch == "J2000"
+    assert info.ra_column == "ra"
+    assert info.dec_column == "dec"
     assert info.primary_catalog == "small_sky_order1"
     assert info.margin_threshold == 7200
 


### PR DESCRIPTION
Adds the catalog specific metadata to the margin catalog info ("epoch", "ra" and "dec"). This enables the fine spatial filtering of margin catalogs when loaded separately from their primary catalogs. Related to https://github.com/astronomy-commons/lsdb/issues/308. Closes #286. 

- [X] My PR includes a link to the issue that I am addressing

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation