### PR TITLE
Use pathlib for test path construction.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import dataclasses
 import os.path
+from pathlib import Path
 from typing import List
 
 import pandas as pd
@@ -27,32 +28,32 @@ TEST_DIR = os.path.dirname(__file__)
 
 @pytest.fixture
 def test_data_dir():
-    return os.path.join(TEST_DIR, DATA_DIR_NAME)
+    return Path(TEST_DIR) / DATA_DIR_NAME
 
 
 @pytest.fixture
 def almanac_dir(test_data_dir):
-    return os.path.join(test_data_dir, ALMANAC_DIR_NAME)
+    return test_data_dir / ALMANAC_DIR_NAME
 
 
 @pytest.fixture
 def small_sky_dir(test_data_dir):
-    return os.path.join(test_data_dir, SMALL_SKY_DIR_NAME)
+    return test_data_dir / SMALL_SKY_DIR_NAME
 
 
 @pytest.fixture
 def small_sky_order1_dir(test_data_dir):
-    return os.path.join(test_data_dir, SMALL_SKY_ORDER1_DIR_NAME)
+    return test_data_dir / SMALL_SKY_ORDER1_DIR_NAME
 
 
 @pytest.fixture
 def small_sky_to_small_sky_order1_dir(test_data_dir):
-    return os.path.join(test_data_dir, SMALL_SKY_TO_SMALL_SKY_ORDER1_DIR_NAME)
+    return test_data_dir / SMALL_SKY_TO_SMALL_SKY_ORDER1_DIR_NAME
 
 
 @pytest.fixture
 def small_sky_source_object_index_dir(test_data_dir):
-    return os.path.join(test_data_dir, SMALL_SKY_SOURCE_OBJECT_INDEX_DIR_NAME)
+    return test_data_dir / SMALL_SKY_SOURCE_OBJECT_INDEX_DIR_NAME
 
 
 @pytest.fixture
@@ -172,12 +173,12 @@ def index_catalog_info_with_extra() -> dict:
 
 @pytest.fixture
 def dataset_path(test_data_dir) -> str:
-    return os.path.join(test_data_dir, "info_only", "dataset")
+    return test_data_dir / "info_only" / "dataset"
 
 
 @pytest.fixture
 def base_catalog_info_file(dataset_path) -> str:
-    return os.path.join(dataset_path, "catalog_info.json")
+    return dataset_path / "catalog_info.json"
 
 
 @pytest.fixture
@@ -187,12 +188,12 @@ def base_catalog_info(base_catalog_info_data) -> BaseCatalogInfo:
 
 @pytest.fixture
 def catalog_path(test_data_dir) -> str:
-    return os.path.join(test_data_dir, "info_only", "catalog")
+    return test_data_dir / "info_only" / "catalog"
 
 
 @pytest.fixture
 def catalog_info_file(catalog_path) -> str:
-    return os.path.join(catalog_path, "catalog_info.json")
+    return catalog_path / "catalog_info.json"
 
 
 @pytest.fixture
@@ -218,7 +219,7 @@ def margin_catalog_pixels() -> List[HealpixPixel]:
 
 @pytest.fixture
 def margin_catalog_path(test_data_dir) -> str:
-    return os.path.join(test_data_dir, "small_sky_order1_margin")
+    return test_data_dir / "small_sky_order1_margin"
 
 
 @pytest.fixture
@@ -228,32 +229,32 @@ def catalog_pixels() -> List[HealpixPixel]:
 
 @pytest.fixture
 def association_catalog_path(test_data_dir) -> str:
-    return os.path.join(test_data_dir, "small_sky_to_small_sky_order1")
+    return test_data_dir / "small_sky_to_small_sky_order1"
 
 
 @pytest.fixture
 def association_catalog_info_file(association_catalog_path) -> str:
-    return os.path.join(association_catalog_path, "catalog_info.json")
+    return association_catalog_path / "catalog_info.json"
 
 
 @pytest.fixture
 def index_catalog_info_file(test_data_dir) -> str:
-    return os.path.join(test_data_dir, "info_only", "index_catalog", "catalog_info.json")
+    return test_data_dir / "info_only" / "index_catalog" / "catalog_info.json"
 
 
 @pytest.fixture
 def margin_cache_catalog_info_file(test_data_dir) -> str:
-    return os.path.join(test_data_dir, "info_only", "margin_cache", "catalog_info.json")
+    return test_data_dir / "info_only" / "margin_cache" / "catalog_info.json"
 
 
 @pytest.fixture
 def source_catalog_info_file(test_data_dir) -> str:
-    return os.path.join(test_data_dir, "small_sky_source", "catalog_info.json")
+    return test_data_dir / "small_sky_source" / "catalog_info.json"
 
 
 @pytest.fixture
 def small_sky_source_dir(test_data_dir) -> str:
-    return os.path.join(test_data_dir, "small_sky_source")
+    return test_data_dir / "small_sky_source"
 
 
 @pytest.fixture
@@ -284,7 +285,7 @@ def association_catalog_info(association_catalog_info_data) -> AssociationCatalo
 
 @pytest.fixture
 def association_catalog_partition_join_file(association_catalog_path) -> str:
-    return os.path.join(association_catalog_path, "partition_join_info.csv")
+    return association_catalog_path / "partition_join_info.csv"
 
 
 @pytest.fixture
@@ -302,7 +303,7 @@ def association_catalog_join_pixels() -> pd.DataFrame:
 @pytest.fixture
 def default_almanac(almanac_dir, test_data_dir):
     """Set up default environment variables and fetch default almanac data."""
-    os.environ["HIPSCAT_ALMANAC_DIR"] = almanac_dir
-    os.environ["HIPSCAT_DEFAULT_DIR"] = test_data_dir
+    os.environ["HIPSCAT_ALMANAC_DIR"] = str(almanac_dir)
+    os.environ["HIPSCAT_DEFAULT_DIR"] = str(test_data_dir)
 
     return Almanac()

--- a/tests/hipscat/catalog/association_catalog/test_association_catalog.py
+++ b/tests/hipscat/catalog/association_catalog/test_association_catalog.py
@@ -54,7 +54,7 @@ def test_read_from_file(association_catalog_path, association_catalog_join_pixel
 
     assert isinstance(catalog, AssociationCatalog)
     assert catalog.on_disk
-    assert catalog.catalog_path == association_catalog_path
+    assert catalog.catalog_path == str(association_catalog_path)
     assert len(catalog.get_join_pixels()) == 4
     assert len(catalog.get_healpix_pixels()) == 1
     pd.testing.assert_frame_equal(catalog.get_join_pixels(), association_catalog_join_pixels)
@@ -73,7 +73,7 @@ def test_empty_directory(tmp_path, association_catalog_info_data, association_ca
     with pytest.raises(FileNotFoundError):
         read_from_hipscat(os.path.join("path", "empty"))
 
-    catalog_path = os.path.join(tmp_path, "empty")
+    catalog_path = tmp_path / "empty"
     os.makedirs(catalog_path, exist_ok=True)
 
     ## Path exists but there's nothing there
@@ -81,7 +81,7 @@ def test_empty_directory(tmp_path, association_catalog_info_data, association_ca
         AssociationCatalog.read_from_hipscat(catalog_path)
 
     ## catalog_info file exists - getting closer
-    file_name = os.path.join(catalog_path, "catalog_info.json")
+    file_name = catalog_path / "catalog_info.json"
     with open(file_name, "w", encoding="utf-8") as metadata_file:
         metadata_file.write(json.dumps(association_catalog_info_data))
 
@@ -101,17 +101,17 @@ def test_csv_round_trip(tmp_path, association_catalog_info_data, association_cat
     with pytest.raises(FileNotFoundError):
         read_from_hipscat(os.path.join("path", "empty"))
 
-    catalog_path = os.path.join(tmp_path, "empty")
+    catalog_path = tmp_path / "empty"
     os.makedirs(catalog_path, exist_ok=True)
 
-    file_name = os.path.join(catalog_path, "catalog_info.json")
+    file_name = catalog_path / "catalog_info.json"
     with open(file_name, "w", encoding="utf-8") as metadata_file:
         metadata_file.write(json.dumps(association_catalog_info_data))
 
     with pytest.raises(FileNotFoundError, match="partition"):
         read_from_hipscat(catalog_path)
 
-    file_name = os.path.join(catalog_path, "partition_info.csv")
+    file_name = catalog_path / "partition_info.csv"
     with open(file_name, "w", encoding="utf-8") as metadata_file:
         # dump some garbage in there - just needs to exist.
         metadata_file.write(json.dumps(association_catalog_info_data))

--- a/tests/hipscat/catalog/association_catalog/test_partition_join_info.py
+++ b/tests/hipscat/catalog/association_catalog/test_partition_join_info.py
@@ -1,5 +1,3 @@
-import os
-
 import pandas as pd
 import pytest
 
@@ -22,14 +20,14 @@ def test_wrong_columns(association_catalog_join_pixels):
 
 
 def test_read_from_metadata(association_catalog_join_pixels, association_catalog_path):
-    file_pointer = file_io.get_file_pointer_from_path(os.path.join(association_catalog_path, "_metadata"))
+    file_pointer = file_io.get_file_pointer_from_path(association_catalog_path / "_metadata")
     info = PartitionJoinInfo.read_from_file(file_pointer)
     pd.testing.assert_frame_equal(info.data_frame, association_catalog_join_pixels)
 
 
 def test_read_from_metadata_fail(tmp_path):
     empty_dataframe = pd.DataFrame()
-    metadata_filename = os.path.join(tmp_path, "empty_metadata.parquet")
+    metadata_filename = tmp_path / "empty_metadata.parquet"
     empty_dataframe.to_parquet(metadata_filename)
     with pytest.raises(ValueError, match="missing columns"):
         PartitionJoinInfo.read_from_file(metadata_filename)
@@ -41,7 +39,7 @@ def test_read_from_metadata_fail(tmp_path):
     valid_ish_dataframe = pd.DataFrame(
         {"data": [0], "Norder": [3], "Npix": [45], "join_Norder": [3], "join_Npix": [45]}
     )
-    metadata_filename = os.path.join(tmp_path, "test_metadata.parquet")
+    metadata_filename = tmp_path / "test_metadata.parquet"
     valid_ish_dataframe.to_parquet(metadata_filename)
     PartitionJoinInfo.read_from_file(metadata_filename)
 
@@ -57,13 +55,13 @@ def test_read_from_metadata_fail(tmp_path):
 
 def test_load_partition_join_info_from_dir_fail(tmp_path):
     empty_dataframe = pd.DataFrame()
-    metadata_filename = os.path.join(tmp_path, "empty_metadata.parquet")
+    metadata_filename = tmp_path / "empty_metadata.parquet"
     empty_dataframe.to_parquet(metadata_filename)
     with pytest.raises(FileNotFoundError, match="_metadata or partition join info"):
         PartitionJoinInfo.read_from_dir(tmp_path)
 
     # The file is there, but doesn't have the required content.
-    metadata_filename = os.path.join(tmp_path, "_metadata")
+    metadata_filename = tmp_path / "_metadata"
     empty_dataframe.to_parquet(metadata_filename)
     with pytest.warns(UserWarning, match="slow"):
         with pytest.raises(ValueError, match="missing columns"):
@@ -91,7 +89,7 @@ def test_metadata_file_round_trip(association_catalog_join_pixels, tmp_path):
     pd.testing.assert_frame_equal(info.data_frame, association_catalog_join_pixels)
     info.write_to_metadata_files(tmp_path)
 
-    file_pointer = file_io.get_file_pointer_from_path(os.path.join(tmp_path, "_metadata"))
+    file_pointer = file_io.get_file_pointer_from_path(tmp_path / "_metadata")
     new_info = PartitionJoinInfo.read_from_file(file_pointer)
     pd.testing.assert_frame_equal(new_info.data_frame, association_catalog_join_pixels)
 
@@ -101,7 +99,7 @@ def test_csv_file_round_trip(association_catalog_join_pixels, tmp_path):
     pd.testing.assert_frame_equal(info.data_frame, association_catalog_join_pixels)
     info.write_to_csv(tmp_path)
 
-    file_pointer = file_io.get_file_pointer_from_path(os.path.join(tmp_path, "partition_join_info.csv"))
+    file_pointer = file_io.get_file_pointer_from_path(tmp_path / "partition_join_info.csv")
     new_info = PartitionJoinInfo.read_from_csv(file_pointer)
     pd.testing.assert_frame_equal(new_info.data_frame, association_catalog_join_pixels)
 
@@ -113,7 +111,7 @@ def test_read_from_csv(association_catalog_partition_join_file, association_cata
 
 
 def test_read_from_missing_file(tmp_path):
-    wrong_path = os.path.join(tmp_path, "wrong")
+    wrong_path = tmp_path / "wrong"
     file_pointer = file_io.get_file_pointer_from_path(wrong_path)
     with pytest.raises(FileNotFoundError):
         PartitionJoinInfo.read_from_csv(file_pointer)

--- a/tests/hipscat/catalog/dataset/test_dataset.py
+++ b/tests/hipscat/catalog/dataset/test_dataset.py
@@ -23,21 +23,21 @@ def test_dataset_wrong_catalog_info(base_catalog_info_data):
 def test_read_from_hipscat(dataset_path, base_catalog_info_file, assert_catalog_info_matches_dict):
     dataset = Dataset.read_from_hipscat(dataset_path)
     assert dataset.on_disk
-    assert dataset.catalog_path == dataset_path
-    assert str(dataset.catalog_base_dir) == dataset_path
+    assert dataset.catalog_path == str(dataset_path)
+    assert dataset.catalog_base_dir == str(dataset_path)
     with open(base_catalog_info_file, "r", encoding="utf-8") as cat_info_file:
         catalog_info_json = json.load(cat_info_file)
         assert_catalog_info_matches_dict(dataset.catalog_info, catalog_info_json)
 
 
 def test_read_from_missing_folder(tmp_path):
-    wrong_path = os.path.join(tmp_path, "wrong")
+    wrong_path = tmp_path / "wrong"
     with pytest.raises(FileNotFoundError, match="directory"):
         Dataset.read_from_hipscat(wrong_path)
 
 
 def test_read_from_empty_folder(tmp_path):
-    dataset_path = os.path.join(tmp_path, "dat")
+    dataset_path = tmp_path / "dat"
     os.makedirs(dataset_path)
     with pytest.raises(FileNotFoundError, match="catalog info"):
         Dataset.read_from_hipscat(dataset_path)

--- a/tests/hipscat/catalog/index/test_index_catalog.py
+++ b/tests/hipscat/catalog/index/test_index_catalog.py
@@ -10,7 +10,7 @@ def test_loc_partition(small_sky_source_object_index_dir):
 
     assert isinstance(catalog, IndexCatalog)
     assert catalog.on_disk
-    assert catalog.catalog_path == small_sky_source_object_index_dir
+    assert catalog.catalog_path == str(small_sky_source_object_index_dir)
 
     npt.assert_array_equal(catalog.loc_partitions([700]), [HealpixPixel(2, 184)])
     npt.assert_array_equal(catalog.loc_partitions([707]), [HealpixPixel(2, 176), HealpixPixel(2, 178)])

--- a/tests/hipscat/catalog/margin_cache/test_margin_catalog.py
+++ b/tests/hipscat/catalog/margin_cache/test_margin_catalog.py
@@ -37,7 +37,7 @@ def test_read_from_file(margin_catalog_path, margin_catalog_pixels):
 
     assert isinstance(catalog, MarginCatalog)
     assert catalog.on_disk
-    assert catalog.catalog_path == margin_catalog_path
+    assert catalog.catalog_path == str(margin_catalog_path)
     assert len(catalog.get_healpix_pixels()) == len(margin_catalog_pixels)
     assert catalog.get_healpix_pixels() == margin_catalog_pixels
 
@@ -58,7 +58,7 @@ def test_empty_directory(tmp_path, margin_cache_catalog_info_data, margin_catalo
     with pytest.raises(FileNotFoundError):
         read_from_hipscat(os.path.join("path", "empty"))
 
-    catalog_path = os.path.join(tmp_path, "empty")
+    catalog_path = tmp_path / "empty"
     os.makedirs(catalog_path, exist_ok=True)
 
     ## Path exists but there's nothing there
@@ -66,7 +66,7 @@ def test_empty_directory(tmp_path, margin_cache_catalog_info_data, margin_catalo
         read_from_hipscat(catalog_path)
 
     ## catalog_info file exists - getting closer
-    file_name = os.path.join(catalog_path, "catalog_info.json")
+    file_name = catalog_path / "catalog_info.json"
     with open(file_name, "w", encoding="utf-8") as metadata_file:
         metadata_file.write(json.dumps(margin_cache_catalog_info_data))
 

--- a/tests/hipscat/catalog/test_catalog.py
+++ b/tests/hipscat/catalog/test_catalog.py
@@ -475,7 +475,7 @@ def test_empty_directory(tmp_path):
     with pytest.raises(FileNotFoundError):
         read_from_hipscat(os.path.join("path", "empty"))
 
-    catalog_path = os.path.join(tmp_path, "empty")
+    catalog_path = tmp_path / "empty"
     os.makedirs(catalog_path, exist_ok=True)
 
     ## Path exists but there's nothing there
@@ -483,7 +483,7 @@ def test_empty_directory(tmp_path):
         read_from_hipscat(catalog_path)
 
     ## catalog_info file exists - getting closer
-    file_name = os.path.join(catalog_path, "catalog_info.json")
+    file_name = catalog_path / "catalog_info.json"
     with open(file_name, "w", encoding="utf-8") as metadata_file:
         metadata_file.write('{"catalog_name":"empty", "catalog_type":"source"}')
 

--- a/tests/hipscat/catalog/test_partition_info.py
+++ b/tests/hipscat/catalog/test_partition_info.py
@@ -1,7 +1,5 @@
 """Tests of partition info functionality"""
 
-import os
-
 import numpy.testing as npt
 import pandas as pd
 import pytest
@@ -38,7 +36,7 @@ def test_load_partition_info_from_metadata(small_sky_dir, small_sky_source_dir, 
 
 def test_load_partition_info_from_metadata_fail(tmp_path):
     empty_dataframe = pd.DataFrame()
-    metadata_filename = os.path.join(tmp_path, "empty_metadata.parquet")
+    metadata_filename = tmp_path / "empty_metadata.parquet"
     empty_dataframe.to_parquet(metadata_filename)
     with pytest.raises(ValueError, match="missing Norder"):
         PartitionInfo.read_from_file(metadata_filename)
@@ -47,7 +45,7 @@ def test_load_partition_info_from_metadata_fail(tmp_path):
         PartitionInfo.read_from_file(metadata_filename, strict=True)
 
     non_healpix_dataframe = pd.DataFrame({"data": [0], "Npix": [45]})
-    metadata_filename = os.path.join(tmp_path, "non_healpix_metadata.parquet")
+    metadata_filename = tmp_path / "non_healpix_metadata.parquet"
     non_healpix_dataframe.to_parquet(metadata_filename)
     with pytest.raises(ValueError, match="missing Norder"):
         PartitionInfo.read_from_file(metadata_filename)
@@ -58,13 +56,13 @@ def test_load_partition_info_from_metadata_fail(tmp_path):
 
 def test_load_partition_info_from_dir_fail(tmp_path):
     empty_dataframe = pd.DataFrame()
-    metadata_filename = os.path.join(tmp_path, "empty_metadata.parquet")
+    metadata_filename = tmp_path / "empty_metadata.parquet"
     empty_dataframe.to_parquet(metadata_filename)
     with pytest.raises(FileNotFoundError, match="_metadata or partition info"):
         PartitionInfo.read_from_dir(tmp_path)
 
     # The file is there, but doesn't have the required content.
-    metadata_filename = os.path.join(tmp_path, "_metadata")
+    metadata_filename = tmp_path / "_metadata"
     empty_dataframe.to_parquet(metadata_filename)
     with pytest.warns(UserWarning, match="slow"):
         with pytest.raises(ValueError, match="missing Norder"):
@@ -88,12 +86,12 @@ def test_load_partition_info_small_sky_order1(small_sky_order1_dir):
 
 
 def test_load_partition_no_file(tmp_path):
-    wrong_path = os.path.join(tmp_path, "_metadata")
+    wrong_path = tmp_path / "_metadata"
     wrong_pointer = file_io.get_file_pointer_from_path(wrong_path)
     with pytest.raises(FileNotFoundError):
         PartitionInfo.read_from_file(wrong_pointer)
 
-    wrong_path = os.path.join(tmp_path, "partition_info.csv")
+    wrong_path = tmp_path, "partition_info.csv"
     wrong_pointer = file_io.get_file_pointer_from_path(wrong_path)
     with pytest.raises(FileNotFoundError):
         PartitionInfo.read_from_csv(wrong_pointer)
@@ -152,7 +150,7 @@ def test_load_partition_info_from_dir_and_write(tmp_path, pixel_list_depth_first
     ##  - full path to the csv file
     info.write_to_file()
     info.write_to_file(catalog_path=tmp_path)
-    info.write_to_file(partition_info_file=os.path.join(tmp_path, "new_csv.csv"))
+    info.write_to_file(partition_info_file=tmp_path / "new_csv.csv")
 
     ## Can write out the _metadata file by providing:
     ##  - no arguments

--- a/tests/hipscat/inspection/test_almanac.py
+++ b/tests/hipscat/inspection/test_almanac.py
@@ -7,12 +7,12 @@ from hipscat.inspection.almanac import Almanac
 
 def test_default(almanac_dir, test_data_dir):
     """Test loading from a default directory"""
-    os.environ["HIPSCAT_DEFAULT_DIR"] = test_data_dir
+    os.environ["HIPSCAT_DEFAULT_DIR"] = str(test_data_dir)
 
     alms = Almanac(include_default_dir=True)
     assert len(alms.catalogs()) == 0
 
-    os.environ["HIPSCAT_ALMANAC_DIR"] = almanac_dir
+    os.environ["HIPSCAT_ALMANAC_DIR"] = str(almanac_dir)
     alms = Almanac(include_default_dir=True)
     assert len(alms.catalogs()) == 7
 
@@ -23,7 +23,7 @@ def test_default(almanac_dir, test_data_dir):
 
 def test_non_default(almanac_dir, test_data_dir):
     """Test loading with explicit (non-default) almanac base directory."""
-    os.environ["HIPSCAT_DEFAULT_DIR"] = test_data_dir
+    os.environ["HIPSCAT_DEFAULT_DIR"] = str(test_data_dir)
 
     alms = Almanac(include_default_dir=False)
     assert len(alms.catalogs()) == 0
@@ -37,8 +37,8 @@ def test_non_default(almanac_dir, test_data_dir):
     alms = Almanac(
         include_default_dir=False,
         dirs=[
-            os.path.join(almanac_dir, "small_sky.yml"),
-            os.path.join(almanac_dir, "small_sky_source.yml"),
+            almanac_dir / "small_sky.yml",
+            almanac_dir / "small_sky_source.yml",
         ],
     )
     assert len(alms.catalogs()) == 2
@@ -46,8 +46,8 @@ def test_non_default(almanac_dir, test_data_dir):
 
 def test_namespaced(almanac_dir, test_data_dir):
     """Test that we can add duplicate catalogs, so long as we add a namespace."""
-    os.environ["HIPSCAT_ALMANAC_DIR"] = almanac_dir
-    os.environ["HIPSCAT_DEFAULT_DIR"] = test_data_dir
+    os.environ["HIPSCAT_ALMANAC_DIR"] = str(almanac_dir)
+    os.environ["HIPSCAT_DEFAULT_DIR"] = str(test_data_dir)
 
     with pytest.warns(match="Duplicate"):
         Almanac(include_default_dir=True, dirs=almanac_dir)
@@ -110,9 +110,7 @@ def test_linked_catalogs_source(default_almanac, test_data_dir):
     assert len(source_almanac.objects) == 1
 
     ## This source catalog has no object catalog, *and that's ok*
-    new_almanac = Almanac(
-        dirs=os.path.join(test_data_dir, "almanac_exception", "standalone_source_catalog.yml")
-    )
+    new_almanac = Almanac(dirs=test_data_dir / "almanac_exception" / "standalone_source_catalog.yml")
     source_almanac = new_almanac.get_almanac_info("just_the_small_sky_source")
     assert len(source_almanac.objects) == 0
 
@@ -171,7 +169,7 @@ def test_get_catalog(default_almanac):
 
 def test_get_catalog_exceptions(test_data_dir):
     """Test that we can create almanac entries, where catalogs might not exist."""
-    bad_catalog_path_file = os.path.join(test_data_dir, "almanac_exception", "bad_catalog_path.yml")
+    bad_catalog_path_file = test_data_dir / "almanac_exception" / "bad_catalog_path.yml"
 
     bad_links = Almanac(include_default_dir=False, dirs=bad_catalog_path_file)
     assert len(bad_links.catalogs()) == 1
@@ -207,7 +205,7 @@ def test_get_catalog_exceptions(test_data_dir):
 )
 def test_almanac_creation(test_data_dir, file_name, expected_error_match):
     """Test that we throw exceptions, where bad almanac data or links exist in the files."""
-    bad_links_file = os.path.join(test_data_dir, "almanac_exception", file_name)
+    bad_links_file = test_data_dir / "almanac_exception" / file_name
 
     with pytest.warns(match=expected_error_match):
         Almanac(dirs=bad_links_file)

--- a/tests/hipscat/inspection/test_almanac_info.py
+++ b/tests/hipscat/inspection/test_almanac_info.py
@@ -29,7 +29,7 @@ def test_write_to_file(tmp_path, association_catalog_path):
 
     almanac_info.write_to_file(tmp_path, default_dir=False)
 
-    new_info = AlmanacInfo.from_file(os.path.join(tmp_path, "small_sky_to_small_sky_order1.yml"))
+    new_info = AlmanacInfo.from_file(tmp_path / "small_sky_to_small_sky_order1.yml")
 
     assert new_info.catalog_name == almanac_info.catalog_name
 

--- a/tests/hipscat/io/file_io/test_file_io.py
+++ b/tests/hipscat/io/file_io/test_file_io.py
@@ -1,5 +1,4 @@
 import json
-import os
 
 import numpy as np
 import pandas as pd
@@ -21,7 +20,7 @@ from hipscat.io.paths import pixel_catalog_file
 
 
 def test_make_directory(tmp_path):
-    test_dir_path = os.path.join(tmp_path, "test_path")
+    test_dir_path = tmp_path / "test_path"
     assert not does_file_or_directory_exist(test_dir_path)
     test_dir_pointer = get_file_pointer_from_path(test_dir_path)
     make_directory(test_dir_pointer)
@@ -29,7 +28,7 @@ def test_make_directory(tmp_path):
 
 
 def test_make_existing_directory_raises(tmp_path):
-    test_dir_path = os.path.join(tmp_path, "test_path")
+    test_dir_path = tmp_path / "test_path"
     make_directory(test_dir_path)
     assert does_file_or_directory_exist(test_dir_path)
     test_dir_pointer = get_file_pointer_from_path(test_dir_path)
@@ -38,9 +37,9 @@ def test_make_existing_directory_raises(tmp_path):
 
 
 def test_make_existing_directory_existok(tmp_path):
-    test_dir_path = os.path.join(tmp_path, "test_path")
+    test_dir_path = tmp_path / "test_path"
     make_directory(test_dir_path)
-    test_inner_dir_path = os.path.join(test_dir_path, "test_inner")
+    test_inner_dir_path = test_dir_path / "test_inner"
     make_directory(test_inner_dir_path)
     assert does_file_or_directory_exist(test_dir_path)
     assert does_file_or_directory_exist(test_inner_dir_path)
@@ -51,7 +50,7 @@ def test_make_existing_directory_existok(tmp_path):
 
 
 def test_make_and_remove_directory(tmp_path):
-    test_dir_path = os.path.join(tmp_path, "test_path")
+    test_dir_path = tmp_path / "test_path"
     assert not does_file_or_directory_exist(test_dir_path)
     test_dir_pointer = get_file_pointer_from_path(test_dir_path)
     make_directory(test_dir_pointer)
@@ -69,7 +68,7 @@ def test_make_and_remove_directory(tmp_path):
 
 
 def test_write_string_to_file(tmp_path):
-    test_file_path = os.path.join(tmp_path, "text_file.txt")
+    test_file_path = tmp_path / "text_file.txt"
     test_file_pointer = get_file_pointer_from_path(test_file_path)
     test_string = "this is a test"
     write_string_to_file(test_file_pointer, test_string, encoding="utf-8")
@@ -81,7 +80,7 @@ def test_write_string_to_file(tmp_path):
 
 
 def test_load_json(small_sky_dir):
-    catalog_info_path = os.path.join(small_sky_dir, "catalog_info.json")
+    catalog_info_path = small_sky_dir / "catalog_info.json"
     json_dict = None
     with open(catalog_info_path, "r", encoding="utf-8") as json_file:
         json_dict = json.load(json_file)
@@ -99,7 +98,7 @@ def test_load_parquet_to_pandas(small_sky_dir):
 
 def test_write_df_to_csv(tmp_path):
     random_df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)), columns=list("ABCD"))
-    test_file_path = os.path.join(tmp_path, "test.csv")
+    test_file_path = tmp_path / "test.csv"
     test_file_pointer = get_file_pointer_from_path(test_file_path)
     write_dataframe_to_csv(random_df, test_file_pointer, index=False)
     loaded_df = pd.read_csv(test_file_path)
@@ -108,7 +107,7 @@ def test_write_df_to_csv(tmp_path):
 
 def test_read_parquet_data(tmp_path):
     random_df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)), columns=list("ABCD"))
-    test_file_path = os.path.join(tmp_path, "test.parquet")
+    test_file_path = tmp_path / "test.parquet"
     random_df.to_parquet(test_file_path)
     file_pointer = get_file_pointer_from_path(test_file_path)
     dataframe = read_parquet_file_to_pandas(file_pointer)

--- a/tests/hipscat/io/file_io/test_file_pointers.py
+++ b/tests/hipscat/io/file_io/test_file_pointers.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pytest
 
@@ -23,7 +23,7 @@ def test_get_pointer_from_path(tmp_path):
 
 
 def test_get_basename_from_filepointer(tmp_path):
-    catalog_info_string = os.path.join(tmp_path, "catalog_info.json")
+    catalog_info_string = tmp_path / "catalog_info.json"
     catalog_info_pointer = get_file_pointer_from_path(catalog_info_string)
     assert get_basename_from_filepointer(catalog_info_pointer) == "catalog_info.json"
 
@@ -31,30 +31,30 @@ def test_get_basename_from_filepointer(tmp_path):
 def test_file_or_dir_exist(small_sky_dir):
     small_sky_pointer = get_file_pointer_from_path(small_sky_dir)
     assert does_file_or_directory_exist(small_sky_pointer)
-    catalog_info_string = os.path.join(small_sky_dir, "catalog_info.json")
+    catalog_info_string = small_sky_dir / "catalog_info.json"
     catalog_info_pointer = get_file_pointer_from_path(catalog_info_string)
     assert does_file_or_directory_exist(catalog_info_pointer)
 
 
 def test_file_or_dir_exist_false(small_sky_dir):
-    small_sky_pointer = get_file_pointer_from_path(small_sky_dir + "incorrect file")
+    small_sky_pointer = get_file_pointer_from_path(str(small_sky_dir) + "incorrect file")
     assert not does_file_or_directory_exist(small_sky_pointer)
 
 
 def test_append_paths_to_pointer(tmp_path):
     test_paths = ["folder", "file.txt"]
-    test_path = os.path.join(tmp_path, *test_paths)
+    test_path = tmp_path / "folder" / "file.txt"
     tmp_pointer = get_file_pointer_from_path(str(tmp_path))
-    assert append_paths_to_pointer(tmp_pointer, *test_paths) == test_path
+    assert append_paths_to_pointer(tmp_pointer, *test_paths) == str(test_path)
 
 
 def test_is_regular_file(small_sky_dir):
-    catalog_info_file = os.path.join(small_sky_dir, "catalog_info.json")
+    catalog_info_file = small_sky_dir / "catalog_info.json"
     assert is_regular_file(catalog_info_file)
 
     assert not is_regular_file(small_sky_dir)
 
-    partition_dir = os.path.join(small_sky_dir, "Norder=0")
+    partition_dir = small_sky_dir / "Norder=0"
     assert not is_regular_file(partition_dir)
 
 
@@ -88,9 +88,7 @@ def test_directory_has_contents(small_sky_order1_dir, tmp_path):
 def test_get_directory_contents(small_sky_order1_dir, tmp_path):
     small_sky_contents = get_directory_contents(small_sky_order1_dir)
 
-    for i, content in enumerate(small_sky_contents):
-        if not content.startswith("/"):
-            small_sky_contents[i] = f"/{content}"
+    small_sky_paths = [Path(p) for p in small_sky_contents]
 
     expected = [
         "Norder=1",
@@ -103,9 +101,9 @@ def test_get_directory_contents(small_sky_order1_dir, tmp_path):
         "provenance_info.json",
     ]
 
-    expected = [os.path.join(small_sky_order1_dir, file_name) for file_name in expected]
+    expected = [small_sky_order1_dir / file_name for file_name in expected]
 
-    assert small_sky_contents == expected
+    assert small_sky_paths == expected
 
     assert len(get_directory_contents(tmp_path)) == 0
 
@@ -142,8 +140,8 @@ def test_strip_leading_slash_for_pyarrow():
         strip_leading_slash_for_pyarrow(test_leading_slash_filename, protocol="abfs")
         == "bucket/path/test.txt"
     )
-    test_non_leading_slash_filenaem = get_file_pointer_from_path("bucket/path/test.txt")
+    test_non_leading_slash_filename = get_file_pointer_from_path("bucket/path/test.txt")
     assert (
-        strip_leading_slash_for_pyarrow(test_non_leading_slash_filenaem, protocol="abfs")
+        strip_leading_slash_for_pyarrow(test_non_leading_slash_filename, protocol="abfs")
         == "bucket/path/test.txt"
     )

--- a/tests/hipscat/io/test_write_metadata.py
+++ b/tests/hipscat/io/test_write_metadata.py
@@ -1,6 +1,5 @@
 """Tests of file IO (reads and writes)"""
 
-import os
 import shutil
 from pathlib import Path
 
@@ -52,7 +51,7 @@ def test_write_json_file(assert_text_file_matches, tmp_path):
     dictionary["pixel"] = HealpixPixel(5, 9_000)
     dictionary["pixels"] = np.array([HealpixPixel(5, 9_000), HealpixPixel(5, 9_001)])
 
-    json_filename = os.path.join(tmp_path, "dictionary.json")
+    json_filename = tmp_path / "dictionary.json"
     io.write_json_file(dictionary, json_filename)
     assert_text_file_matches(expected_lines, json_filename)
 
@@ -71,14 +70,14 @@ def test_write_json_paths(assert_text_file_matches, tmp_path):
         '    "first_greek": "alpha"',
         "}",
     ]
-    json_filename = os.path.join(tmp_path, "dictionary.json")
+    json_filename = tmp_path / "dictionary.json"
     io.write_json_file(dictionary, json_filename)
     assert_text_file_matches(expected_lines, json_filename)
 
 
 def test_write_catalog_info(assert_text_file_matches, tmp_path, catalog_info):
     """Test that we accurately write out catalog metadata"""
-    catalog_base_dir = os.path.join(tmp_path, "test_name")
+    catalog_base_dir = tmp_path / "test_name"
     file_io.make_directory(catalog_base_dir)
     expected_lines = [
         "{",
@@ -92,13 +91,13 @@ def test_write_catalog_info(assert_text_file_matches, tmp_path, catalog_info):
     ]
 
     io.write_catalog_info(dataset_info=catalog_info, catalog_base_dir=catalog_base_dir)
-    metadata_filename = os.path.join(catalog_base_dir, "catalog_info.json")
+    metadata_filename = catalog_base_dir / "catalog_info.json"
     assert_text_file_matches(expected_lines, metadata_filename)
 
 
 def test_write_provenance_info(assert_text_file_matches, tmp_path, catalog_info):
     """Test that we accurately write out tool-provided generation metadata"""
-    catalog_base_dir = os.path.join(tmp_path, "test_name")
+    catalog_base_dir = tmp_path / "test_name"
     file_io.make_directory(catalog_base_dir)
     expected_lines = [
         "{",
@@ -131,13 +130,13 @@ def test_write_provenance_info(assert_text_file_matches, tmp_path, catalog_info)
     io.write_provenance_info(
         catalog_base_dir=catalog_base_dir, dataset_info=catalog_info, tool_args=tool_args
     )
-    metadata_filename = os.path.join(catalog_base_dir, "provenance_info.json")
+    metadata_filename = catalog_base_dir / "provenance_info.json"
     assert_text_file_matches(expected_lines, metadata_filename)
 
 
 def test_write_partition_info_healpix_pixel_map(assert_text_file_matches, tmp_path):
     """Test that we accurately write out the partition stats for overloaded input"""
-    catalog_base_dir = os.path.join(tmp_path, "test_name")
+    catalog_base_dir = tmp_path / "test_name"
     file_io.make_directory(catalog_base_dir)
     expected_lines = [
         "Norder,Dir,Npix,num_rows",
@@ -145,7 +144,7 @@ def test_write_partition_info_healpix_pixel_map(assert_text_file_matches, tmp_pa
     ]
     pixel_map = {HealpixPixel(0, 11): (131, [11])}
     io.write_partition_info(catalog_base_dir, destination_healpix_pixel_map=pixel_map)
-    metadata_filename = os.path.join(catalog_base_dir, "partition_info.csv")
+    metadata_filename = catalog_base_dir / "partition_info.csv"
     assert_text_file_matches(expected_lines, metadata_filename)
 
     expected_lines = [
@@ -160,14 +159,14 @@ def test_write_partition_info_healpix_pixel_map(assert_text_file_matches, tmp_pa
         HealpixPixel(1, 46): (51, [46]),
     }
     io.write_partition_info(catalog_base_dir, destination_healpix_pixel_map=pixel_map)
-    metadata_filename = os.path.join(catalog_base_dir, "partition_info.csv")
+    metadata_filename = catalog_base_dir / "partition_info.csv"
     assert_text_file_matches(expected_lines, metadata_filename)
 
 
 def test_write_partition_info_float(assert_text_file_matches, tmp_path):
     """Test that we accurately write out the individual partition stats
     even when the input is floats instead of ints"""
-    catalog_base_dir = os.path.join(tmp_path, "test_name")
+    catalog_base_dir = tmp_path / "test_name"
     file_io.make_directory(catalog_base_dir)
     expected_lines = [
         "Norder,Dir,Npix,num_rows",
@@ -175,7 +174,7 @@ def test_write_partition_info_float(assert_text_file_matches, tmp_path):
     ]
     pixel_map = {HealpixPixel(0.0, 11.0): (131, [44.0, 45.0, 46.0])}
     io.write_partition_info(catalog_base_dir, pixel_map)
-    metadata_filename = os.path.join(catalog_base_dir, "partition_info.csv")
+    metadata_filename = catalog_base_dir / "partition_info.csv"
     assert_text_file_matches(expected_lines, metadata_filename)
 
 
@@ -183,25 +182,25 @@ def test_write_parquet_metadata(
     tmp_path, small_sky_dir, basic_catalog_parquet_metadata, check_parquet_schema
 ):
     """Copy existing catalog and create new metadata files for it"""
-    catalog_base_dir = os.path.join(tmp_path, "catalog")
+    catalog_base_dir = tmp_path / "catalog"
     shutil.copytree(
         small_sky_dir,
         catalog_base_dir,
     )
     io.write_parquet_metadata(catalog_base_dir)
-    check_parquet_schema(os.path.join(catalog_base_dir, "_metadata"), basic_catalog_parquet_metadata)
+    check_parquet_schema(catalog_base_dir / "_metadata", basic_catalog_parquet_metadata)
     ## _common_metadata has 0 row groups
     check_parquet_schema(
-        os.path.join(catalog_base_dir, "_common_metadata"),
+        catalog_base_dir / "_common_metadata",
         basic_catalog_parquet_metadata,
         0,
     )
     ## Re-write - should still have the same properties.
     io.write_parquet_metadata(catalog_base_dir)
-    check_parquet_schema(os.path.join(catalog_base_dir, "_metadata"), basic_catalog_parquet_metadata)
+    check_parquet_schema(catalog_base_dir / "_metadata", basic_catalog_parquet_metadata)
     ## _common_metadata has 0 row groups
     check_parquet_schema(
-        os.path.join(catalog_base_dir, "_common_metadata"),
+        catalog_base_dir / "_common_metadata",
         basic_catalog_parquet_metadata,
         0,
     )
@@ -214,7 +213,7 @@ def test_read_write_fits_point_map(tmp_path):
     initial_histogram[44:] = filled_pixels[:]
     io.write_fits_map(tmp_path, initial_histogram)
 
-    output_file = os.path.join(tmp_path, "point_map.fits")
+    output_file = tmp_path / "point_map.fits"
 
     output = file_io.read_fits_image(output_file)
     npt.assert_array_equal(output, initial_histogram)
@@ -232,7 +231,7 @@ def test_read_write_fits_point_map(tmp_path):
 
 def test_read_ring_fits_point_map(tmp_path):
     """Check that we write and can read a FITS file for spatial distribution."""
-    output_file = os.path.join(tmp_path, "point_map.fits")
+    output_file = tmp_path / "point_map.fits"
     initial_histogram = hist.empty_histogram(1)
     filled_pixels = [51, 29, 51, 0]
     initial_histogram[44:] = filled_pixels[:]

--- a/tests/hipscat/pixel_tree/conftest.py
+++ b/tests/hipscat/pixel_tree/conftest.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from hipscat.pixel_math import HealpixPixel
@@ -8,7 +6,7 @@ from hipscat.pixel_tree.pixel_tree import PixelTree
 
 @pytest.fixture
 def pixel_trees_dir(test_data_dir):
-    return os.path.join(test_data_dir, "pixel_trees")
+    return test_data_dir / "pixel_trees"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Change Description

This PR touches only files under tests/, and changes code to use pathlib.Path for constructing test data paths, instead of `os.path.join`.

This shouldn't change any functionality, but is just cleaner.