### PR TITLE
Fix smoke test, uses pathlib

### DIFF
--- a/tests/hipscat/io/file_io/test_file_io.py
+++ b/tests/hipscat/io/file_io/test_file_io.py
@@ -116,20 +116,20 @@ def test_read_parquet_data(tmp_path):
 
 
 def test_read_parquet_dataset(small_sky_dir, small_sky_order1_dir):
-    (_, ds) = read_parquet_dataset(os.path.join(small_sky_dir, "Norder=0"))
+    (_, ds) = read_parquet_dataset(small_sky_dir / "Norder=0")
 
     assert ds.count_rows() == 131
 
-    (_, ds) = read_parquet_dataset([os.path.join(small_sky_dir, "Norder=0", "Dir=0", "Npix=11.parquet")])
+    (_, ds) = read_parquet_dataset([small_sky_dir / "Norder=0" / "Dir=0" / "Npix=11.parquet"])
 
     assert ds.count_rows() == 131
 
     (_, ds) = read_parquet_dataset(
         [
-            os.path.join(small_sky_order1_dir, "Norder=1", "Dir=0", "Npix=44.parquet"),
-            os.path.join(small_sky_order1_dir, "Norder=1", "Dir=0", "Npix=45.parquet"),
-            os.path.join(small_sky_order1_dir, "Norder=1", "Dir=0", "Npix=46.parquet"),
-            os.path.join(small_sky_order1_dir, "Norder=1", "Dir=0", "Npix=47.parquet"),
+            small_sky_order1_dir / "Norder=1" / "Dir=0" / "Npix=44.parquet",
+            small_sky_order1_dir / "Norder=1" / "Dir=0" / "Npix=45.parquet",
+            small_sky_order1_dir / "Norder=1" / "Dir=0" / "Npix=46.parquet",
+            small_sky_order1_dir / "Norder=1" / "Dir=0" / "Npix=47.parquet",
         ]
     )
 


### PR DESCRIPTION
## Change Description

Addresses smoke test failure.

There was an unfortunate merge combination with https://github.com/astronomy-commons/hipscat/pull/289 and https://github.com/astronomy-commons/hipscat/pull/288, where one uses `os.path.join`, and the other removes the `import os` statement. This updates to use pathlib for test path construction.

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation