### PR TITLE
added support to url params on pixel_catalog_files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dynamic = ["version"]
 
 requires-python = ">=3.9"
 dependencies = [
+    "aiohttp", # http filesystem support
     "astropy",
     "fsspec>=2023.10.0", # Used for abstract filesystems
     "healpy",

--- a/src/hipscat/io/paths.py
+++ b/src/hipscat/io/paths.py
@@ -149,9 +149,14 @@ def dict_to_query_urlparams(query_params: dict) -> str:
 
     query = {}
     for key, value in query_params.items():
+        if not all([key, value]):
+            continue
         if isinstance(value, list):
             value = ",".join(value).replace(" ", "")
         query[key] = value
+
+    if not query:
+        return ""
 
     # Build the query string and add the "?" prefix
     url_params = "?" + urlencode(query, doseq=True)

--- a/src/hipscat/io/paths.py
+++ b/src/hipscat/io/paths.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from typing import Dict, List
-from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+from urllib.parse import urlencode
 
 from fsspec.implementations.http import HTTPFileSystem
 

--- a/tests/hipscat/io/test_paths.py
+++ b/tests/hipscat/io/test_paths.py
@@ -54,6 +54,30 @@ def test_pixel_catalog_files():
     assert expected == result
 
 
+def test_pixel_catalog_files_w_query_params():
+    expected = [
+        "https://foo/Norder=0/Dir=0/Npix=5.parquet?columns=ID%2CRA%2CDEC%2Cr_auto&filters=r_auto%3C13"
+    ]
+    query_params = {"columns": ["ID", "RA", "DEC", "r_auto"], "filters": ["r_auto<13"]}
+    result = paths.pixel_catalog_files("https://foo", [HealpixPixel(0, 5)], query_params=query_params)
+    assert expected == result
+
+
+def test_dict_to_query_urlparams():
+    expected = "?columns=ID%2CRA%2CDEC%2Cr_auto&filters=r_auto%3C13"
+    query_params = {"columns": ["ID", "RA", "DEC", "r_auto"], "filters": ["r_auto<13"]}
+    result = paths.dict_to_query_urlparams(query_params)
+    assert result == expected
+
+    expected = "?columns=ID%2CRA%2CDEC%2Cr_auto&filters=r_auto%3C13"
+    query_params = {"columns": [" ID", "RA ", "DEC ", "r_auto"], "filters": ["r_auto < 13"]}
+    result = paths.dict_to_query_urlparams(query_params)
+    assert result == expected
+
+    result = paths.dict_to_query_urlparams({})
+    assert result == ""
+
+
 def test_get_healpix_from_path():
     expected = HealpixPixel(5, 34)
 

--- a/tests/hipscat/io/test_paths.py
+++ b/tests/hipscat/io/test_paths.py
@@ -77,6 +77,18 @@ def test_dict_to_query_urlparams():
     result = paths.dict_to_query_urlparams({})
     assert result == ""
 
+    result = paths.dict_to_query_urlparams(None)
+    assert result == ""
+
+    result = paths.dict_to_query_urlparams({"": ""})
+    assert result == ""
+
+    result = paths.dict_to_query_urlparams({None: ""})
+    assert result == ""
+
+    result = paths.dict_to_query_urlparams({"": "nonempty"})
+    assert result == ""
+
 
 def test_get_healpix_from_path():
     expected = HealpixPixel(5, 34)


### PR DESCRIPTION
This adds support to url query params to use for example with our parquet-server.

- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My change includes backwards compatibility
- [x] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have added unit/End-to-End (E2E) test cases to cover any changes
