### PR TITLE
Readd `compute_pixel_map`

### DIFF
--- a/src/hipscat/pixel_math/__init__.py
+++ b/src/hipscat/pixel_math/__init__.py
@@ -4,5 +4,5 @@ from .healpix_pixel import HealpixPixel
 from .healpix_pixel_convertor import HealpixInputTypes, get_healpix_pixel
 from .hipscat_id import compute_hipscat_id, hipscat_id_to_healpix
 from .margin_bounding import check_margin_bounds
-from .partition_stats import empty_histogram, generate_alignment, generate_histogram
+from .partition_stats import compute_pixel_map, empty_histogram, generate_alignment, generate_histogram
 from .pixel_margins import get_edge, get_margin, pixel_is_polar

--- a/src/hipscat/pixel_math/partition_stats.py
+++ b/src/hipscat/pixel_math/partition_stats.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 import hipscat.pixel_math.healpix_shim as hp
+from hipscat.pixel_math import HealpixPixel
 
 
 def empty_histogram(highest_order):
@@ -203,3 +204,81 @@ def _get_alignment_dropping_siblings(nested_sums, highest_order, lowest_order, t
     ]
 
     return np.array(nested_alignment, dtype="object")
+
+
+def compute_pixel_map(histogram, highest_order=10, lowest_order=0, threshold=1_000_000):
+    # pylint: disable=too-many-locals
+    """Generate alignment from high order pixels to those of equal or lower order
+    We may initially find healpix pixels at order 10, but after aggregating up to the pixel
+    threshold, some final pixels are order 4 or 7. This method provides a map from destination
+    healpix pixels at a lower order to the origin pixels at the highest order. This may be used
+    as an input into later partitioning map reduce steps.
+    Args:
+        histogram (:obj:`np.array`): one-dimensional numpy array of long integers where the
+            value at each index corresponds to the number of objects found at the healpix pixel.
+        highest_order (int):  the highest healpix order (e.g. 0-10)
+        lowest_order (int): the lowest healpix order (e.g. 1-5). specifying a lowest order
+            constrains the partitioning to prevent spatially large pixels.
+        threshold (int): the maximum number of objects allowed in a single pixel
+    Returns:
+        dictionary that maps the HealpixPixel (a pixel at destination order) to a tuple of
+        origin pixel information.
+        The tuple contains the following:
+        - 0 - the total number of rows found in this destination pixel
+        - 1 - the set of indexes in histogram for the pixels at the original healpix order.
+    Raises:
+        ValueError: if the histogram is the wrong size, or some initial histogram bins
+            exceed threshold.
+    """
+    if len(histogram) != hp.order2npix(highest_order):
+        raise ValueError("histogram is not the right size")
+    if lowest_order > highest_order:
+        raise ValueError("lowest_order should be less than highest_order")
+    max_bin = np.amax(histogram)
+    if max_bin > threshold:
+        raise ValueError(f"single pixel count {max_bin} exceeds threshold {threshold}")
+
+    nested_sums = []
+
+    for order in range(0, highest_order):
+        explosion_factor = 4 ** (highest_order - order)
+        nested_sums.append(histogram.reshape(-1, explosion_factor).sum(axis=1))
+    nested_sums.append(histogram)
+
+    ## Determine the lowest order that does not exceed the threshold
+    orders_at_threshold = [lowest_order if 0 < k <= threshold else None for k in nested_sums[lowest_order]]
+    for order in range(lowest_order + 1, highest_order + 1):
+        new_orders_at_threshold = np.array(
+            [order if 0 < k <= threshold else None for k in nested_sums[order]]
+        )
+        parent_alignment = np.repeat(orders_at_threshold, 4, axis=0)
+        orders_at_threshold = [
+            parent_order if parent_order is not None else new_order
+            for parent_order, new_order in zip(parent_alignment, new_orders_at_threshold)
+        ]
+
+    ## Zip up the orders and the pixel numbers.
+    healpix_pixels = np.array(
+        [
+            HealpixPixel(order, pixel >> 2 * (highest_order - order)) if order is not None else None
+            for order, pixel in zip(orders_at_threshold, np.arange(0, len(orders_at_threshold)))
+        ]
+    )
+
+    ## Create a map from healpix pixel to origin pixel data
+    non_none_elements = healpix_pixels[healpix_pixels != np.array(None)]
+    unique_pixels = np.unique(non_none_elements)
+
+    result = {}
+    for healpix_pixel in unique_pixels:
+        # Find all nonzero constituent pixels at the histogram's order
+        explosion_factor = 4 ** (highest_order - healpix_pixel.order)
+        start_pixel = healpix_pixel.pixel * explosion_factor
+        end_pixel = (healpix_pixel.pixel + 1) * explosion_factor
+
+        non_zero_indexes = np.nonzero(histogram[start_pixel:end_pixel])[0] + start_pixel
+        result[healpix_pixel] = (
+            nested_sums[healpix_pixel.order][healpix_pixel.pixel],
+            non_zero_indexes.tolist(),
+        )
+    return result

--- a/tests/hipscat/pixel_math/test_partition_stats.py
+++ b/tests/hipscat/pixel_math/test_partition_stats.py
@@ -7,6 +7,7 @@ import pytest
 
 import hipscat.pixel_math as hist
 import hipscat.pixel_math.healpix_shim as hp
+from hipscat.pixel_math import HealpixPixel
 
 
 def test_small_sky_same_pixel():
@@ -196,3 +197,67 @@ def test_alignment_even_sky(drop_empty_siblings):
     # everything maps to order 7 (would be 5, but lowest of 7 is enforced)
     for mapping in result:
         assert mapping[0] == 7
+
+
+def test_compute_pixel_map_order1():
+    """Create destination pixel map for small sky at order 1"""
+
+    initial_histogram = hist.empty_histogram(1)
+    filled_pixels = [51, 29, 51, 0]
+    initial_histogram[44:] = filled_pixels[:]
+
+    expected = {HealpixPixel(0, 11): (131, [44, 45, 46])}
+
+    result = hist.compute_pixel_map(initial_histogram, highest_order=1, threshold=150)
+
+    npt.assert_array_equal(result, expected)
+
+    expected = {
+        HealpixPixel(1, 44): (51, [44]),
+        HealpixPixel(1, 45): (29, [45]),
+        HealpixPixel(1, 46): (51, [46]),
+    }
+
+    result = hist.compute_pixel_map(initial_histogram, highest_order=1, threshold=100)
+
+    npt.assert_array_equal(result, expected)
+
+
+@pytest.mark.timeout(5)
+def test_compute_pixel_map_even_sky():
+    """Create alignment from an even distribution at order 6"""
+    initial_histogram = np.full(hp.order2npix(6), 200)
+    result = hist.compute_pixel_map(initial_histogram, highest_order=6, threshold=1_000)
+    # everything maps to order 5, given the density
+    for mapping in result:
+        assert mapping.order == 5
+
+
+@pytest.mark.timeout(5)
+def test_compute_pixel_map_even_sky_enforce_lowest():
+    """Create pixel map for an even distribution, and enforce a lowest order bound."""
+    initial_histogram = np.full(hp.order2npix(6), 10)
+    result = hist.compute_pixel_map(initial_histogram, highest_order=6, lowest_order=4, threshold=1_000)
+    # everything maps to order 4 (would be 0, but lowest of 4 is enforced)
+    for mapping in result:
+        assert mapping.order == 4
+
+
+def test_compute_pixel_map_invalid_inputs():
+    """Create destination pixel map for small sky at order 1"""
+
+    initial_histogram = hist.empty_histogram(1)
+    filled_pixels = [51, 29, 51, 0]
+    initial_histogram[44:] = filled_pixels[:]
+
+    ## Order doesn't match histogram length
+    with pytest.raises(ValueError, match="histogram is not the right size"):
+        hist.compute_pixel_map(initial_histogram, highest_order=2, threshold=150)
+
+    ## Some bins exceed threshold
+    with pytest.raises(ValueError, match="exceeds threshold"):
+        hist.compute_pixel_map(initial_histogram, highest_order=1, threshold=30)
+
+    ## lowest_order too large
+    with pytest.raises(ValueError, match="lowest_order"):
+        hist.compute_pixel_map(initial_histogram, highest_order=1, lowest_order=2, threshold=30)


### PR DESCRIPTION
The `compute_pixel_map` method was removed from HiPSCat but it's still in use in LSDB.

- [ ] My PR includes a link to the issue that I am addressing

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation