### PR TITLE
Pass compression kwargs through file system open.

### DIFF
--- a/src/hipscat/io/file_io/file_io.py
+++ b/src/hipscat/io/file_io/file_io.py
@@ -166,7 +166,7 @@ def load_csv_to_pandas_generator(
         pandas dataframe loaded from CSV
     """
     file_system, file_pointer = get_fs(file_pointer, storage_options=storage_options)
-    with file_system.open(file_pointer, "r") as csv_file:
+    with file_system.open(file_pointer, "r", **kwargs) as csv_file:
         with pd.read_csv(csv_file, chunksize=chunksize, **kwargs) as reader:
             yield from reader
 

--- a/tests/hipscat/io/file_io/test_file_io.py
+++ b/tests/hipscat/io/file_io/test_file_io.py
@@ -1,9 +1,9 @@
 import json
 
 import numpy as np
+import pandas as pd
 import pytest
 
-import pandas as pd
 from hipscat.io.file_io import (
     delete_file,
     get_file_pointer_from_path,

--- a/tests/hipscat/io/file_io/test_file_io.py
+++ b/tests/hipscat/io/file_io/test_file_io.py
@@ -1,9 +1,9 @@
 import json
 
 import numpy as np
-import pandas as pd
 import pytest
 
+import pandas as pd
 from hipscat.io.file_io import (
     delete_file,
     get_file_pointer_from_path,
@@ -126,7 +126,7 @@ def test_load_csv_to_pandas(small_sky_source_dir):
 def test_load_csv_to_pandas_generator(small_sky_source_dir):
     partition_info_path = small_sky_source_dir / "partition_info.csv"
     num_reads = 0
-    for frame in load_csv_to_pandas_generator(partition_info_path, chunksize=7):
+    for frame in load_csv_to_pandas_generator(partition_info_path, chunksize=7, compression=None):
         assert len(frame) == 7
         num_reads += 1
     assert num_reads == 2

--- a/tests/hipscat/pixel_tree/conftest.py
+++ b/tests/hipscat/pixel_tree/conftest.py
@@ -15,23 +15,8 @@ def pixel_tree_1():
 
 
 @pytest.fixture
-def pixel_tree_2_pixels():
-    return [
-        HealpixPixel(2, 128),
-        HealpixPixel(2, 130),
-        HealpixPixel(2, 131),
-        HealpixPixel(1, 33),
-        HealpixPixel(1, 35),
-        HealpixPixel(0, 10),
-        HealpixPixel(1, 44),
-        HealpixPixel(1, 45),
-        HealpixPixel(1, 46),
-    ]
-
-
-@pytest.fixture
-def pixel_tree_2(pixel_tree_2_pixels):
-    return PixelTree.from_healpix(pixel_tree_2_pixels)
+def pixel_tree_2(pixel_list_breadth_first):
+    return PixelTree.from_healpix(pixel_list_breadth_first)
 
 
 @pytest.fixture

--- a/tests/hipscat/pixel_tree/test_pixel_tree.py
+++ b/tests/hipscat/pixel_tree/test_pixel_tree.py
@@ -15,8 +15,8 @@ def test_pixel_tree_length():
             assert len(tree) == length
 
 
-def test_get_healpix_pixels(pixel_tree_2, pixel_tree_2_pixels):
-    assert pixel_tree_2.get_healpix_pixels() == pixel_tree_2_pixels
+def test_get_healpix_pixels(pixel_tree_2, pixel_list_breadth_first):
+    assert pixel_tree_2.get_healpix_pixels() == pixel_list_breadth_first
 
 
 def test_pixel_tree_max_depth(pixel_tree_1, pixel_tree_2, pixel_tree_3):


### PR DESCRIPTION
## Change Description

Related to https://github.com/astronomy-commons/hipscat-import/issues/369

Pandas does not infer compression when passed a file handle. Further, pandas will not use any `compression` kwarg passed if the input is a file handle. The compression needs to be handled when the file is opened (and it's now opened by the file system object, as of PR #315)