### PR TITLE
Replace FilePointer with universal pathlib

### DIFF
--- a/docs/notebooks/catalog_size_inspection.ipynb
+++ b/docs/notebooks/catalog_size_inspection.ipynb
@@ -34,6 +34,7 @@
    "outputs": [],
    "source": [
     "import hipscat\n",
+    "from hipscat.pixel_math import HealpixPixel\n",
     "import os\n",
     "\n",
     "### Change this path!!!\n",
@@ -48,7 +49,7 @@
     "\n",
     "for index, partition in info_frame.iterrows():\n",
     "    file_name = result = hipscat.io.paths.pixel_catalog_file(\n",
-    "        catalog_dir, partition[\"Norder\"], partition[\"Npix\"]\n",
+    "        catalog_dir, HealpixPixel(partition[\"Norder\"], partition[\"Npix\"])\n",
     "    )\n",
     "    info_frame.loc[index, \"size_on_disk\"] = os.path.getsize(file_name)\n",
     "\n",
@@ -128,6 +129,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "hipscatenv",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -138,7 +144,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pandas",
     "pyarrow>=14.0.1",
     "typing-extensions>=4.3.0",
+    "universal-pathlib",
 ]
 
 [project.urls]

--- a/src/hipscat/catalog/association_catalog/association_catalog.py
+++ b/src/hipscat/catalog/association_catalog/association_catalog.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Tuple, Union
+from typing import Tuple, Union
 
 import pandas as pd
 import pyarrow as pa
@@ -38,13 +38,10 @@ class AssociationCatalog(HealpixDataset):
         catalog_path=None,
         moc: MOC | None = None,
         schema: pa.Schema | None = None,
-        storage_options: Union[Dict[Any, Any], None] = None,
     ) -> None:
         if not catalog_info.catalog_type == CatalogType.ASSOCIATION:
             raise ValueError("Catalog info `catalog_type` must be 'association'")
-        super().__init__(
-            catalog_info, pixels, catalog_path, moc=moc, schema=schema, storage_options=storage_options
-        )
+        super().__init__(catalog_info, pixels, catalog_path, moc=moc, schema=schema)
         self.join_info = self._get_partition_join_info_from_pixels(join_pixels)
 
     def get_join_pixels(self) -> pd.DataFrame:
@@ -68,22 +65,20 @@ class AssociationCatalog(HealpixDataset):
 
     @classmethod
     def _read_args(
-        cls, catalog_base_dir: UPath, storage_options: Union[Dict[Any, Any], None] = None
+        cls, catalog_base_dir: UPath
     ) -> Tuple[CatalogInfoClass, PixelInputTypes, JoinPixelInputTypes]:  # type: ignore[override]
-        args = super()._read_args(catalog_base_dir, storage_options=storage_options)
-        partition_join_info = PartitionJoinInfo.read_from_dir(
-            catalog_base_dir, storage_options=storage_options
-        )
+        args = super()._read_args(catalog_base_dir)
+        partition_join_info = PartitionJoinInfo.read_from_dir(catalog_base_dir)
         return args + (partition_join_info,)
 
     @classmethod
-    def _check_files_exist(cls, catalog_base_dir: UPath, storage_options: dict = None):
-        super()._check_files_exist(catalog_base_dir, storage_options=storage_options)
+    def _check_files_exist(cls, catalog_base_dir: UPath):
+        super()._check_files_exist(catalog_base_dir)
         partition_join_info_file = paths.get_partition_join_info_pointer(catalog_base_dir)
         metadata_file = paths.get_parquet_metadata_pointer(catalog_base_dir)
         if not (
-            file_io.does_file_or_directory_exist(partition_join_info_file, storage_options=storage_options)
-            or file_io.does_file_or_directory_exist(metadata_file, storage_options=storage_options)
+            file_io.does_file_or_directory_exist(partition_join_info_file)
+            or file_io.does_file_or_directory_exist(metadata_file)
         ):
             raise FileNotFoundError(
                 f"_metadata or partition join info file is required in catalog directory {catalog_base_dir}"

--- a/src/hipscat/catalog/association_catalog/association_catalog.py
+++ b/src/hipscat/catalog/association_catalog/association_catalog.py
@@ -6,12 +6,13 @@ import pandas as pd
 import pyarrow as pa
 from mocpy import MOC
 from typing_extensions import TypeAlias
+from upath import UPath
 
 from hipscat.catalog.association_catalog.association_catalog_info import AssociationCatalogInfo
 from hipscat.catalog.association_catalog.partition_join_info import PartitionJoinInfo
 from hipscat.catalog.catalog_type import CatalogType
 from hipscat.catalog.healpix_dataset.healpix_dataset import HealpixDataset, PixelInputTypes
-from hipscat.io import FilePointer, file_io, paths
+from hipscat.io import file_io, paths
 
 
 class AssociationCatalog(HealpixDataset):
@@ -67,7 +68,7 @@ class AssociationCatalog(HealpixDataset):
 
     @classmethod
     def _read_args(
-        cls, catalog_base_dir: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
+        cls, catalog_base_dir: UPath, storage_options: Union[Dict[Any, Any], None] = None
     ) -> Tuple[CatalogInfoClass, PixelInputTypes, JoinPixelInputTypes]:  # type: ignore[override]
         args = super()._read_args(catalog_base_dir, storage_options=storage_options)
         partition_join_info = PartitionJoinInfo.read_from_dir(
@@ -76,7 +77,7 @@ class AssociationCatalog(HealpixDataset):
         return args + (partition_join_info,)
 
     @classmethod
-    def _check_files_exist(cls, catalog_base_dir: FilePointer, storage_options: dict = None):
+    def _check_files_exist(cls, catalog_base_dir: UPath, storage_options: dict = None):
         super()._check_files_exist(catalog_base_dir, storage_options=storage_options)
         partition_join_info_file = paths.get_partition_join_info_pointer(catalog_base_dir)
         metadata_file = paths.get_parquet_metadata_pointer(catalog_base_dir)

--- a/src/hipscat/catalog/association_catalog/partition_join_info.py
+++ b/src/hipscat/catalog/association_catalog/partition_join_info.py
@@ -71,12 +71,11 @@ class PartitionJoinInfo:
         primary_to_join = dict(primary_to_join)
         return primary_to_join
 
-    def write_to_metadata_files(self, catalog_path: UPath = None, storage_options: dict = None):
+    def write_to_metadata_files(self, catalog_path: UPath = None):
         """Generate parquet metadata, using the known partitions.
 
         Args:
             catalog_path (UPath): base path for the catalog
-            storage_options (dict): dictionary that contains abstract filesystem credentials
 
         Returns:
             sum of the number of rows in the dataset.
@@ -105,9 +104,9 @@ class PartitionJoinInfo:
             for primary_pixel, join_pixels in self.primary_to_join_map().items()
         ]
 
-        return write_parquet_metadata_for_batches(batches, catalog_path, storage_options)
+        return write_parquet_metadata_for_batches(batches, catalog_path)
 
-    def write_to_csv(self, catalog_path: UPath = None, storage_options: dict = None):
+    def write_to_csv(self, catalog_path: UPath = None):
         """Write all partition data to CSV files.
 
         Two files will be written:
@@ -119,7 +118,6 @@ class PartitionJoinInfo:
         Args:
             catalog_path: UPath to the directory where the
                 `partition_join_info.csv` file will be written
-            storage_options (dict): dictionary that contains abstract filesystem credentials
 
         Raises:
             ValueError: if no path is provided, and could not be inferred.
@@ -130,19 +128,15 @@ class PartitionJoinInfo:
             catalog_path = self.catalog_base_dir
 
         partition_join_info_file = paths.get_partition_join_info_pointer(catalog_path)
-        file_io.write_dataframe_to_csv(
-            self.data_frame, partition_join_info_file, index=False, storage_options=storage_options
-        )
+        file_io.write_dataframe_to_csv(self.data_frame, partition_join_info_file, index=False)
 
         primary_pixels = self.primary_to_join_map().keys()
         partition_info_pointer = paths.get_partition_info_pointer(catalog_path)
         partition_info = PartitionInfo.from_healpix(primary_pixels)
-        partition_info.write_to_file(
-            partition_info_file=partition_info_pointer, storage_options=storage_options
-        )
+        partition_info.write_to_file(partition_info_file=partition_info_pointer)
 
     @classmethod
-    def read_from_dir(cls, catalog_base_dir: UPath, storage_options: dict = None) -> PartitionJoinInfo:
+    def read_from_dir(cls, catalog_base_dir: UPath) -> PartitionJoinInfo:
         """Read partition join info from a file within a hipscat directory.
 
         This will look for a `partition_join_info.csv` file, and if not found, will look for
@@ -152,7 +146,6 @@ class PartitionJoinInfo:
 
         Args:
             catalog_base_dir: path to the root directory of the catalog
-            storage_options (dict): dictionary that contains abstract filesystem credentials
 
         Returns:
             A `PartitionJoinInfo` object with the data from the file
@@ -162,15 +155,11 @@ class PartitionJoinInfo:
         """
         metadata_file = paths.get_parquet_metadata_pointer(catalog_base_dir)
         partition_join_info_file = paths.get_partition_join_info_pointer(catalog_base_dir)
-        if file_io.does_file_or_directory_exist(partition_join_info_file, storage_options=storage_options):
-            pixel_frame = PartitionJoinInfo._read_from_csv(
-                partition_join_info_file, storage_options=storage_options
-            )
-        elif file_io.does_file_or_directory_exist(metadata_file, storage_options=storage_options):
+        if file_io.does_file_or_directory_exist(partition_join_info_file):
+            pixel_frame = PartitionJoinInfo._read_from_csv(partition_join_info_file)
+        elif file_io.does_file_or_directory_exist(metadata_file):
             warnings.warn("Reading partitions from parquet metadata. This is typically slow.")
-            pixel_frame = PartitionJoinInfo._read_from_metadata_file(
-                metadata_file, storage_options=storage_options
-            )
+            pixel_frame = PartitionJoinInfo._read_from_metadata_file(metadata_file)
         else:
             raise FileNotFoundError(
                 f"_metadata or partition join info file is required in catalog directory {catalog_base_dir}"
@@ -178,31 +167,25 @@ class PartitionJoinInfo:
         return cls(pixel_frame, catalog_base_dir)
 
     @classmethod
-    def read_from_file(
-        cls, metadata_file: UPath, strict: bool = False, storage_options: dict = None
-    ) -> PartitionJoinInfo:
+    def read_from_file(cls, metadata_file: UPath, strict: bool = False) -> PartitionJoinInfo:
         """Read partition join info from a `_metadata` file to create an object
 
         Args:
             metadata_file (UPath): UPath to the `_metadata` file
-            storage_options (dict): dictionary that contains abstract filesystem credentials
             strict (bool): use strict parsing of _metadata file. this is slower, but
                 gives more helpful error messages in the case of invalid data.
 
         Returns:
             A `PartitionJoinInfo` object with the data from the file
         """
-        return cls(cls._read_from_metadata_file(metadata_file, strict, storage_options))
+        return cls(cls._read_from_metadata_file(metadata_file, strict))
 
     @classmethod
-    def _read_from_metadata_file(
-        cls, metadata_file: UPath, strict: bool = False, storage_options: dict = None
-    ) -> pd.DataFrame:
+    def _read_from_metadata_file(cls, metadata_file: UPath, strict: bool = False) -> pd.DataFrame:
         """Read partition join info from a `_metadata` file to create an object
 
         Args:
             metadata_file (UPath): UPath to the `_metadata` file
-            storage_options (dict): dictionary that contains abstract filesystem credentials
             strict (bool): use strict parsing of _metadata file. this is slower, but
                 gives more helpful error messages in the case of invalid data.
 
@@ -218,12 +201,12 @@ class PartitionJoinInfo:
                         row_group_stat_single_value(row_group, cls.JOIN_ORDER_COLUMN_NAME),
                         row_group_stat_single_value(row_group, cls.JOIN_PIXEL_COLUMN_NAME),
                     )
-                    for row_group in read_row_group_fragments(metadata_file, storage_options)
+                    for row_group in read_row_group_fragments(metadata_file)
                 ],
                 columns=cls.COLUMN_NAMES,
             )
         else:
-            total_metadata = file_io.read_parquet_metadata(metadata_file, storage_options)
+            total_metadata = file_io.read_parquet_metadata(metadata_file)
             num_row_groups = total_metadata.num_row_groups
 
             first_row_group = total_metadata.row_group(0)
@@ -273,36 +256,30 @@ class PartitionJoinInfo:
         return pixel_frame
 
     @classmethod
-    def read_from_csv(
-        cls, partition_join_info_file: UPath, storage_options: dict = None
-    ) -> PartitionJoinInfo:
+    def read_from_csv(cls, partition_join_info_file: UPath) -> PartitionJoinInfo:
         """Read partition join info from a `partition_join_info.csv` file to create an object
 
         Args:
             partition_join_info_file (UPath): UPath to the `partition_join_info.csv` file
-            storage_options (dict): dictionary that contains abstract filesystem credentials
 
         Returns:
             A `PartitionJoinInfo` object with the data from the file
         """
-        return cls(cls._read_from_csv(partition_join_info_file, storage_options))
+        return cls(cls._read_from_csv(partition_join_info_file))
 
     @classmethod
-    def _read_from_csv(cls, partition_join_info_file: UPath, storage_options: dict = None) -> pd.DataFrame:
+    def _read_from_csv(cls, partition_join_info_file: UPath) -> pd.DataFrame:
         """Read partition join info from a `partition_join_info.csv` file to create an object
 
         Args:
             partition_join_info_file (UPath): UPath to the `partition_join_info.csv` file
-            storage_options (dict): dictionary that contains abstract filesystem credentials
 
         Returns:
             A `PartitionJoinInfo` object with the data from the file
         """
-        if not file_io.does_file_or_directory_exist(
-            partition_join_info_file, storage_options=storage_options
-        ):
+        if not file_io.does_file_or_directory_exist(partition_join_info_file):
             raise FileNotFoundError(
                 f"No partition join info found where expected: {str(partition_join_info_file)}"
             )
 
-        return file_io.load_csv_to_pandas(partition_join_info_file, storage_options=storage_options)
+        return file_io.load_csv_to_pandas(partition_join_info_file)

--- a/src/hipscat/catalog/association_catalog/partition_join_info.py
+++ b/src/hipscat/catalog/association_catalog/partition_join_info.py
@@ -8,9 +8,10 @@ from typing import Dict, List
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+from upath import UPath
 
 from hipscat.catalog.partition_info import PartitionInfo
-from hipscat.io import FilePointer, file_io, paths
+from hipscat.io import file_io, paths
 from hipscat.io.parquet_metadata import (
     read_row_group_fragments,
     row_group_stat_single_value,
@@ -70,11 +71,11 @@ class PartitionJoinInfo:
         primary_to_join = dict(primary_to_join)
         return primary_to_join
 
-    def write_to_metadata_files(self, catalog_path: FilePointer = None, storage_options: dict = None):
+    def write_to_metadata_files(self, catalog_path: UPath = None, storage_options: dict = None):
         """Generate parquet metadata, using the known partitions.
 
         Args:
-            catalog_path (FilePointer): base path for the catalog
+            catalog_path (UPath): base path for the catalog
             storage_options (dict): dictionary that contains abstract filesystem credentials
 
         Returns:
@@ -106,7 +107,7 @@ class PartitionJoinInfo:
 
         return write_parquet_metadata_for_batches(batches, catalog_path, storage_options)
 
-    def write_to_csv(self, catalog_path: FilePointer = None, storage_options: dict = None):
+    def write_to_csv(self, catalog_path: UPath = None, storage_options: dict = None):
         """Write all partition data to CSV files.
 
         Two files will be written:
@@ -116,7 +117,7 @@ class PartitionJoinInfo:
               join catalogs.
 
         Args:
-            catalog_path: FilePointer to the directory where the
+            catalog_path: UPath to the directory where the
                 `partition_join_info.csv` file will be written
             storage_options (dict): dictionary that contains abstract filesystem credentials
 
@@ -141,7 +142,7 @@ class PartitionJoinInfo:
         )
 
     @classmethod
-    def read_from_dir(cls, catalog_base_dir: FilePointer, storage_options: dict = None) -> PartitionJoinInfo:
+    def read_from_dir(cls, catalog_base_dir: UPath, storage_options: dict = None) -> PartitionJoinInfo:
         """Read partition join info from a file within a hipscat directory.
 
         This will look for a `partition_join_info.csv` file, and if not found, will look for
@@ -178,12 +179,12 @@ class PartitionJoinInfo:
 
     @classmethod
     def read_from_file(
-        cls, metadata_file: FilePointer, strict: bool = False, storage_options: dict = None
+        cls, metadata_file: UPath, strict: bool = False, storage_options: dict = None
     ) -> PartitionJoinInfo:
         """Read partition join info from a `_metadata` file to create an object
 
         Args:
-            metadata_file (FilePointer): FilePointer to the `_metadata` file
+            metadata_file (UPath): UPath to the `_metadata` file
             storage_options (dict): dictionary that contains abstract filesystem credentials
             strict (bool): use strict parsing of _metadata file. this is slower, but
                 gives more helpful error messages in the case of invalid data.
@@ -195,12 +196,12 @@ class PartitionJoinInfo:
 
     @classmethod
     def _read_from_metadata_file(
-        cls, metadata_file: FilePointer, strict: bool = False, storage_options: dict = None
+        cls, metadata_file: UPath, strict: bool = False, storage_options: dict = None
     ) -> pd.DataFrame:
         """Read partition join info from a `_metadata` file to create an object
 
         Args:
-            metadata_file (FilePointer): FilePointer to the `_metadata` file
+            metadata_file (UPath): UPath to the `_metadata` file
             storage_options (dict): dictionary that contains abstract filesystem credentials
             strict (bool): use strict parsing of _metadata file. this is slower, but
                 gives more helpful error messages in the case of invalid data.
@@ -273,12 +274,12 @@ class PartitionJoinInfo:
 
     @classmethod
     def read_from_csv(
-        cls, partition_join_info_file: FilePointer, storage_options: dict = None
+        cls, partition_join_info_file: UPath, storage_options: dict = None
     ) -> PartitionJoinInfo:
         """Read partition join info from a `partition_join_info.csv` file to create an object
 
         Args:
-            partition_join_info_file (FilePointer): FilePointer to the `partition_join_info.csv` file
+            partition_join_info_file (UPath): UPath to the `partition_join_info.csv` file
             storage_options (dict): dictionary that contains abstract filesystem credentials
 
         Returns:
@@ -287,13 +288,11 @@ class PartitionJoinInfo:
         return cls(cls._read_from_csv(partition_join_info_file, storage_options))
 
     @classmethod
-    def _read_from_csv(
-        cls, partition_join_info_file: FilePointer, storage_options: dict = None
-    ) -> pd.DataFrame:
+    def _read_from_csv(cls, partition_join_info_file: UPath, storage_options: dict = None) -> pd.DataFrame:
         """Read partition join info from a `partition_join_info.csv` file to create an object
 
         Args:
-            partition_join_info_file (FilePointer): FilePointer to the `partition_join_info.csv` file
+            partition_join_info_file (UPath): UPath to the `partition_join_info.csv` file
             storage_options (dict): dictionary that contains abstract filesystem credentials
 
         Returns:

--- a/src/hipscat/catalog/catalog.py
+++ b/src/hipscat/catalog/catalog.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Tuple, Union
+from typing import List, Tuple
 
 import numpy as np
 import pyarrow as pa
 from mocpy import MOC
 from typing_extensions import TypeAlias
+from upath import UPath
 
 import hipscat.pixel_math.healpix_shim as hp
 from hipscat.catalog.catalog_info import CatalogInfo
@@ -45,10 +46,9 @@ class Catalog(HealpixDataset):
         self,
         catalog_info: CatalogInfoClass,
         pixels: PixelInputTypes,
-        catalog_path: str = None,
+        catalog_path: UPath = None,
         moc: MOC | None = None,
         schema: pa.Schema | None = None,
-        storage_options: Union[Dict[Any, Any], None] = None,
     ) -> None:
         """Initializes a Catalog
 
@@ -60,7 +60,6 @@ class Catalog(HealpixDataset):
                 Does not load the catalog from this path, only store as metadata
             moc (mocpy.MOC): MOC object representing the coverage of the catalog
             schema (pa.Schema): The pyarrow schema for the catalog
-            storage_options: dictionary that contains abstract filesystem credentials
         """
         if catalog_info.catalog_type not in self.HIPS_CATALOG_TYPES:
             raise ValueError(
@@ -73,7 +72,6 @@ class Catalog(HealpixDataset):
             catalog_path=catalog_path,
             moc=moc,
             schema=schema,
-            storage_options=storage_options,
         )
 
     def filter_by_cone(self, ra: float, dec: float, radius_arcsec: float) -> Catalog:

--- a/src/hipscat/catalog/dataset/base_catalog_info.py
+++ b/src/hipscat/catalog/dataset/base_catalog_info.py
@@ -5,9 +5,10 @@ from dataclasses import dataclass
 from typing import Any, Dict, Union
 
 from typing_extensions import Self
+from upath import UPath
 
 from hipscat.catalog.catalog_type import CatalogType
-from hipscat.io import FilePointer, file_io
+from hipscat.io import file_io
 
 
 @dataclass
@@ -46,12 +47,12 @@ class BaseCatalogInfo:
 
     @classmethod
     def read_from_metadata_file(
-        cls, catalog_info_file: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
+        cls, catalog_info_file: UPath, storage_options: Union[Dict[Any, Any], None] = None
     ) -> Self:
         """Read catalog info from the `catalog_info.json` metadata file
 
         Args:
-            catalog_info_file: FilePointer pointing to the `catalog_info.json` file
+            catalog_info_file: UPath pointing to the `catalog_info.json` file
             storage_options: dictionary that contains abstract filesystem credentials
 
         Returns:

--- a/src/hipscat/catalog/dataset/base_catalog_info.py
+++ b/src/hipscat/catalog/dataset/base_catalog_info.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import dataclasses
 from dataclasses import dataclass
-from typing import Any, Dict, Union
 
 from typing_extensions import Self
 from upath import UPath
@@ -46,19 +45,16 @@ class BaseCatalogInfo:
         return formatted_string
 
     @classmethod
-    def read_from_metadata_file(
-        cls, catalog_info_file: UPath, storage_options: Union[Dict[Any, Any], None] = None
-    ) -> Self:
+    def read_from_metadata_file(cls, catalog_info_file: UPath) -> Self:
         """Read catalog info from the `catalog_info.json` metadata file
 
         Args:
             catalog_info_file: UPath pointing to the `catalog_info.json` file
-            storage_options: dictionary that contains abstract filesystem credentials
 
         Returns:
             A CatalogInfo object with the data from the `catalog_info.json` file
         """
-        metadata_keywords = file_io.load_json_file(catalog_info_file, storage_options=storage_options)
+        metadata_keywords = file_io.load_json_file(catalog_info_file)
         catalog_info_keywords = {}
         for field in dataclasses.fields(cls):
             if field.name in metadata_keywords:

--- a/src/hipscat/catalog/dataset/catalog_info_factory.py
+++ b/src/hipscat/catalog/dataset/catalog_info_factory.py
@@ -1,6 +1,8 @@
 import dataclasses
 from typing import Any, Dict, Optional, Union
 
+from upath import UPath
+
 from hipscat.catalog.association_catalog.association_catalog_info import AssociationCatalogInfo
 from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.catalog.catalog_type import CatalogType
@@ -8,7 +10,7 @@ from hipscat.catalog.dataset.base_catalog_info import BaseCatalogInfo
 from hipscat.catalog.index.index_catalog_info import IndexCatalogInfo
 from hipscat.catalog.margin_cache.margin_cache_catalog_info import MarginCacheCatalogInfo
 from hipscat.catalog.source_catalog.source_catalog_info import SourceCatalogInfo
-from hipscat.io import FilePointer, file_io, paths
+from hipscat.io import file_io, paths
 
 CATALOG_TYPE_TO_INFO_CLASS = {
     CatalogType.OBJECT: CatalogInfo,
@@ -51,7 +53,7 @@ def create_catalog_info(keywords: dict, catalog_type: Optional[CatalogType] = No
     return ci_class(**catalog_info_keywords)
 
 
-def from_catalog_dir(catalog_base_dir: FilePointer, storage_options: Union[Dict[Any, Any], None] = None):
+def from_catalog_dir(catalog_base_dir: UPath, storage_options: Union[Dict[Any, Any], None] = None):
     """Generate a typed catalog info object from the type specified in the
     catalog info file.
 

--- a/src/hipscat/catalog/dataset/catalog_info_factory.py
+++ b/src/hipscat/catalog/dataset/catalog_info_factory.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, Dict, Optional, Union
+from typing import Optional
 
 from upath import UPath
 
@@ -36,7 +36,7 @@ def create_catalog_info(keywords: dict, catalog_type: Optional[CatalogType] = No
     """
 
     if not catalog_type:
-        if "catalog_type" not in keywords.keys():
+        if "catalog_type" not in keywords:
             raise ValueError("catalog type is required to create catalog info object")
         catalog_type = keywords["catalog_type"]
 
@@ -53,22 +53,21 @@ def create_catalog_info(keywords: dict, catalog_type: Optional[CatalogType] = No
     return ci_class(**catalog_info_keywords)
 
 
-def from_catalog_dir(catalog_base_dir: UPath, storage_options: Union[Dict[Any, Any], None] = None):
+def from_catalog_dir(catalog_base_dir: UPath):
     """Generate a typed catalog info object from the type specified in the
     catalog info file.
 
     Args:
         catalog_base_dir: a path pointing to the base directory of a catalog,
             or may point to a ``catalog_info.json`` file directly.
-        storage_options: dictionary that contains abstract filesystem credentials
 
     Returns:
         populated BaseCatalogInfo of appropriate type.
     """
-    if file_io.is_regular_file(catalog_base_dir, storage_options=storage_options):
+    if file_io.is_regular_file(catalog_base_dir):
         ## This might be the catalog_info.json file - try anyway
-        metadata_keywords = file_io.load_json_file(catalog_base_dir, storage_options=storage_options)
+        metadata_keywords = file_io.load_json_file(catalog_base_dir)
     else:
         catalog_info_file = paths.get_catalog_info_pointer(catalog_base_dir)
-        metadata_keywords = file_io.load_json_file(catalog_info_file, storage_options=storage_options)
+        metadata_keywords = file_io.load_json_file(catalog_info_file)
     return create_catalog_info(metadata_keywords)

--- a/src/hipscat/catalog/dataset/dataset.py
+++ b/src/hipscat/catalog/dataset/dataset.py
@@ -32,7 +32,7 @@ class Dataset:
         self.catalog_base_dir = file_io.get_upath(self.catalog_path)
 
     @classmethod
-    def read_from_hipscat(cls, catalog_path: str) -> Self:
+    def read_from_hipscat(cls, catalog_path: UPath | str) -> Self:
         """Reads a HiPSCat Catalog from a HiPSCat directory
 
         Args:

--- a/src/hipscat/catalog/dataset/dataset.py
+++ b/src/hipscat/catalog/dataset/dataset.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 from typing_extensions import Self

--- a/src/hipscat/catalog/dataset/dataset.py
+++ b/src/hipscat/catalog/dataset/dataset.py
@@ -1,9 +1,10 @@
 from typing import Any, Dict, Tuple, Union
 
 from typing_extensions import Self
+from upath import UPath
 
 from hipscat.catalog.dataset.base_catalog_info import BaseCatalogInfo
-from hipscat.io import FilePointer, file_io, paths
+from hipscat.io import file_io, paths
 
 
 class Dataset:
@@ -35,7 +36,7 @@ class Dataset:
         self.catalog_path = catalog_path
         self.on_disk = catalog_path is not None
         self.storage_options = storage_options
-        self.catalog_base_dir = file_io.get_file_pointer_from_path(self.catalog_path)
+        self.catalog_base_dir = file_io.get_upath(self.catalog_path)
 
     @classmethod
     def read_from_hipscat(
@@ -50,7 +51,7 @@ class Dataset:
         Returns:
             The initialized catalog object
         """
-        catalog_base_dir = file_io.get_file_pointer_from_path(catalog_path)
+        catalog_base_dir = file_io.get_upath(catalog_path)
         cls._check_files_exist(catalog_base_dir, storage_options=storage_options)
         args = cls._read_args(catalog_base_dir, storage_options=storage_options)
         kwargs = cls._read_kwargs(catalog_base_dir, storage_options=storage_options)
@@ -58,7 +59,7 @@ class Dataset:
 
     @classmethod
     def _read_args(
-        cls, catalog_base_dir: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
+        cls, catalog_base_dir: UPath, storage_options: Union[Dict[Any, Any], None] = None
     ) -> Tuple[CatalogInfoClass]:
         catalog_info_file = paths.get_catalog_info_pointer(catalog_base_dir)
         catalog_info = cls.CatalogInfoClass.read_from_metadata_file(
@@ -68,14 +69,12 @@ class Dataset:
 
     @classmethod
     def _read_kwargs(
-        cls, catalog_base_dir: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
+        cls, catalog_base_dir: UPath, storage_options: Union[Dict[Any, Any], None] = None
     ) -> dict:
-        return {"catalog_path": str(catalog_base_dir), "storage_options": storage_options}
+        return {"catalog_path": catalog_base_dir, "storage_options": storage_options}
 
     @classmethod
-    def _check_files_exist(
-        cls, catalog_base_dir: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
-    ):
+    def _check_files_exist(cls, catalog_base_dir: UPath, storage_options: Union[Dict[Any, Any], None] = None):
         if not file_io.does_file_or_directory_exist(catalog_base_dir, storage_options=storage_options):
             raise FileNotFoundError(f"No directory exists at {str(catalog_base_dir)}")
         catalog_info_file = paths.get_catalog_info_pointer(catalog_base_dir)

--- a/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
@@ -9,11 +9,12 @@ import pandas as pd
 import pyarrow as pa
 from mocpy import MOC
 from typing_extensions import Self, TypeAlias
+from upath import UPath
 
 import hipscat.pixel_math.healpix_shim as hp
 from hipscat.catalog.dataset import BaseCatalogInfo, Dataset
 from hipscat.catalog.partition_info import PartitionInfo
-from hipscat.io import FilePointer, file_io, paths
+from hipscat.io import file_io, paths
 from hipscat.io.file_io import read_parquet_metadata
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_tree import PixelAlignment, PixelAlignmentType
@@ -94,7 +95,7 @@ class HealpixDataset(Dataset):
     @classmethod
     def _read_args(
         cls,
-        catalog_base_dir: FilePointer,
+        catalog_base_dir: UPath,
         storage_options: Union[Dict[Any, Any], None] = None,
     ) -> Tuple[CatalogInfoClass, PartitionInfo]:
         args = super()._read_args(catalog_base_dir, storage_options=storage_options)
@@ -103,7 +104,7 @@ class HealpixDataset(Dataset):
 
     @classmethod
     def _read_kwargs(
-        cls, catalog_base_dir: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
+        cls, catalog_base_dir: UPath, storage_options: Union[Dict[Any, Any], None] = None
     ) -> dict:
         kwargs = super()._read_kwargs(catalog_base_dir, storage_options=storage_options)
         kwargs["moc"] = cls._read_moc_from_point_map(catalog_base_dir, storage_options)
@@ -112,7 +113,7 @@ class HealpixDataset(Dataset):
 
     @classmethod
     def _read_moc_from_point_map(
-        cls, catalog_base_dir: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
+        cls, catalog_base_dir: UPath, storage_options: Union[Dict[Any, Any], None] = None
     ) -> MOC | None:
         """Reads a MOC object from the `point_map.fits` file if it exists in the catalog directory"""
         point_map_path = paths.get_point_map_file_pointer(catalog_base_dir)
@@ -127,7 +128,7 @@ class HealpixDataset(Dataset):
 
     @classmethod
     def _read_schema_from_metadata(
-        cls, catalog_base_dir: FilePointer, storage_options: dict | None = None
+        cls, catalog_base_dir: UPath, storage_options: dict | None = None
     ) -> pa.Schema | None:
         """Reads the schema information stored in the _common_metadata or _metadata files."""
         common_metadata_file = paths.get_common_metadata_pointer(catalog_base_dir)
@@ -147,7 +148,7 @@ class HealpixDataset(Dataset):
         return metadata.schema.to_arrow_schema()
 
     @classmethod
-    def _check_files_exist(cls, catalog_base_dir: FilePointer, storage_options: dict = None):
+    def _check_files_exist(cls, catalog_base_dir: UPath, storage_options: dict = None):
         super()._check_files_exist(catalog_base_dir, storage_options=storage_options)
         partition_info_file = paths.get_partition_info_pointer(catalog_base_dir)
         metadata_file = paths.get_parquet_metadata_pointer(catalog_base_dir)

--- a/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import warnings
-from typing import Any, Dict, List, Tuple, Union
+from typing import List, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -44,7 +44,6 @@ class HealpixDataset(Dataset):
         catalog_path: str = None,
         moc: MOC | None = None,
         schema: pa.Schema | None = None,
-        storage_options: Union[Dict[Any, Any], None] = None,
     ) -> None:
         """Initializes a Catalog
 
@@ -56,9 +55,8 @@ class HealpixDataset(Dataset):
                 Does not load the catalog from this path, only store as metadata
             moc (mocpy.MOC): MOC object representing the coverage of the catalog
             schema (pa.Schema): The pyarrow schema for the catalog
-            storage_options: dictionary that contains abstract filesystem credentials
         """
-        super().__init__(catalog_info, catalog_path=catalog_path, storage_options=storage_options)
+        super().__init__(catalog_info, catalog_path=catalog_path)
         self.partition_info = self._get_partition_info_from_pixels(pixels)
         self.pixel_tree = self._get_pixel_tree_from_pixels(pixels)
         self.moc = moc
@@ -93,33 +91,25 @@ class HealpixDataset(Dataset):
         raise TypeError("Pixels must be of type PartitionInfo, PixelTree, or List[HealpixPixel]")
 
     @classmethod
-    def _read_args(
-        cls,
-        catalog_base_dir: UPath,
-        storage_options: Union[Dict[Any, Any], None] = None,
-    ) -> Tuple[CatalogInfoClass, PartitionInfo]:
-        args = super()._read_args(catalog_base_dir, storage_options=storage_options)
-        partition_info = PartitionInfo.read_from_dir(catalog_base_dir, storage_options=storage_options)
+    def _read_args(cls, catalog_base_dir: UPath) -> Tuple[CatalogInfoClass, PartitionInfo]:
+        args = super()._read_args(catalog_base_dir)
+        partition_info = PartitionInfo.read_from_dir(catalog_base_dir)
         return args + (partition_info,)
 
     @classmethod
-    def _read_kwargs(
-        cls, catalog_base_dir: UPath, storage_options: Union[Dict[Any, Any], None] = None
-    ) -> dict:
-        kwargs = super()._read_kwargs(catalog_base_dir, storage_options=storage_options)
-        kwargs["moc"] = cls._read_moc_from_point_map(catalog_base_dir, storage_options)
-        kwargs["schema"] = cls._read_schema_from_metadata(catalog_base_dir, storage_options)
+    def _read_kwargs(cls, catalog_base_dir: UPath) -> dict:
+        kwargs = super()._read_kwargs(catalog_base_dir)
+        kwargs["moc"] = cls._read_moc_from_point_map(catalog_base_dir)
+        kwargs["schema"] = cls._read_schema_from_metadata(catalog_base_dir)
         return kwargs
 
     @classmethod
-    def _read_moc_from_point_map(
-        cls, catalog_base_dir: UPath, storage_options: Union[Dict[Any, Any], None] = None
-    ) -> MOC | None:
+    def _read_moc_from_point_map(cls, catalog_base_dir: UPath) -> MOC | None:
         """Reads a MOC object from the `point_map.fits` file if it exists in the catalog directory"""
         point_map_path = paths.get_point_map_file_pointer(catalog_base_dir)
-        if not file_io.does_file_or_directory_exist(point_map_path, storage_options=storage_options):
+        if not file_io.does_file_or_directory_exist(point_map_path):
             return None
-        fits_image = file_io.read_fits_image(point_map_path, storage_options=storage_options)
+        fits_image = file_io.read_fits_image(point_map_path)
         order = hp.nside2order(hp.npix2nside(len(fits_image)))
         boolean_skymap = fits_image.astype(bool)
         ipix = np.where(boolean_skymap)[0]
@@ -127,16 +117,12 @@ class HealpixDataset(Dataset):
         return MOC.from_healpix_cells(ipix, orders, order)
 
     @classmethod
-    def _read_schema_from_metadata(
-        cls, catalog_base_dir: UPath, storage_options: dict | None = None
-    ) -> pa.Schema | None:
+    def _read_schema_from_metadata(cls, catalog_base_dir: UPath) -> pa.Schema | None:
         """Reads the schema information stored in the _common_metadata or _metadata files."""
         common_metadata_file = paths.get_common_metadata_pointer(catalog_base_dir)
-        common_metadata_exists = file_io.does_file_or_directory_exist(
-            common_metadata_file, storage_options=storage_options
-        )
+        common_metadata_exists = file_io.does_file_or_directory_exist(common_metadata_file)
         metadata_file = paths.get_parquet_metadata_pointer(catalog_base_dir)
-        metadata_exists = file_io.does_file_or_directory_exist(metadata_file, storage_options=storage_options)
+        metadata_exists = file_io.does_file_or_directory_exist(metadata_file)
         if not (common_metadata_exists or metadata_exists):
             warnings.warn(
                 "_common_metadata or _metadata files not found for this catalog."
@@ -144,17 +130,17 @@ class HealpixDataset(Dataset):
             )
             return None
         schema_file = common_metadata_file if common_metadata_exists else metadata_file
-        metadata = read_parquet_metadata(schema_file, storage_options=storage_options)
+        metadata = read_parquet_metadata(schema_file)
         return metadata.schema.to_arrow_schema()
 
     @classmethod
-    def _check_files_exist(cls, catalog_base_dir: UPath, storage_options: dict = None):
-        super()._check_files_exist(catalog_base_dir, storage_options=storage_options)
+    def _check_files_exist(cls, catalog_base_dir: UPath):
+        super()._check_files_exist(catalog_base_dir)
         partition_info_file = paths.get_partition_info_pointer(catalog_base_dir)
         metadata_file = paths.get_parquet_metadata_pointer(catalog_base_dir)
         if not (
-            file_io.does_file_or_directory_exist(partition_info_file, storage_options=storage_options)
-            or file_io.does_file_or_directory_exist(metadata_file, storage_options=storage_options)
+            file_io.does_file_or_directory_exist(partition_info_file)
+            or file_io.does_file_or_directory_exist(metadata_file)
         ):
             raise FileNotFoundError(
                 f"_metadata or partition info file is required in catalog directory {catalog_base_dir}"
@@ -194,7 +180,7 @@ class HealpixDataset(Dataset):
 
         Returns:
             A new catalog with only the pixels that overlap with the moc. Note that we reset the total_rows
-            to None, as updating would require a scan over the new pixel sizes."""
+        to None, as updating would require a scan over the new pixel sizes."""
         filtered_tree = filter_by_moc(self.pixel_tree, moc)
         filtered_moc = self.moc.intersection(moc) if self.moc is not None else None
         filtered_catalog_info = dataclasses.replace(self.catalog_info, total_rows=None)

--- a/src/hipscat/catalog/index/index_catalog.py
+++ b/src/hipscat/catalog/index/index_catalog.py
@@ -8,7 +8,8 @@ from typing_extensions import TypeAlias
 from hipscat.catalog.dataset import Dataset
 from hipscat.catalog.index import IndexCatalogInfo
 from hipscat.io import paths
-from hipscat.io.file_io.file_pointer import get_fs, strip_leading_slash_for_pyarrow
+
+# from hipscat.io.file_io.file_pointer import get_fs, strip_leading_slash_for_pyarrow
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.healpix_pixel_function import get_pixel_argsort
 
@@ -32,12 +33,12 @@ class IndexCatalog(Dataset):
             that may contain rows for the id values
         """
         metadata_file = paths.get_parquet_metadata_pointer(self.catalog_base_dir)
-        file_system, metadata_file = get_fs(file_pointer=metadata_file, storage_options=self.storage_options)
+        # file_system, metadata_file = get_fs(file_pointer=metadata_file, storage_options=self.storage_options)
 
-        # pyarrow.dataset requires the pointer not lead with a slash
-        metadata_file = strip_leading_slash_for_pyarrow(metadata_file, file_system.protocol)
+        # # pyarrow.dataset requires the pointer not lead with a slash
+        # metadata_file = strip_leading_slash_for_pyarrow(metadata_file, file_system.protocol)
 
-        dataset = pds.parquet_dataset(metadata_file, filesystem=file_system)
+        dataset = pds.parquet_dataset(metadata_file, filesystem=metadata_file.fs)
 
         # There's a lot happening in a few pyarrow dataset methods:
         # We create a simple pyarrow expression that roughly corresponds to a SQL statement like

--- a/src/hipscat/catalog/index/index_catalog.py
+++ b/src/hipscat/catalog/index/index_catalog.py
@@ -33,11 +33,6 @@ class IndexCatalog(Dataset):
             that may contain rows for the id values
         """
         metadata_file = paths.get_parquet_metadata_pointer(self.catalog_base_dir)
-        # file_system, metadata_file = get_fs(file_pointer=metadata_file, storage_options=self.storage_options)
-
-        # # pyarrow.dataset requires the pointer not lead with a slash
-        # metadata_file = strip_leading_slash_for_pyarrow(metadata_file, file_system.protocol)
-
         dataset = pds.parquet_dataset(metadata_file, filesystem=metadata_file.fs)
 
         # There's a lot happening in a few pyarrow dataset methods:

--- a/src/hipscat/catalog/margin_cache/margin_catalog.py
+++ b/src/hipscat/catalog/margin_cache/margin_catalog.py
@@ -32,7 +32,6 @@ class MarginCatalog(HealpixDataset):
         catalog_path: str = None,
         moc: MOC | None = None,
         schema: pa.Schema | None = None,
-        storage_options: dict | None = None,
     ) -> None:
         """Initializes a Margin Catalog
 
@@ -44,7 +43,6 @@ class MarginCatalog(HealpixDataset):
                 Does not load the catalog from this path, only store as metadata
             moc (mocpy.MOC): MOC object representing the coverage of the catalog
             schema (pa.Schema): The pyarrow schema for the catalog
-            storage_options: dictionary that contains abstract filesystem credentials
         """
         if catalog_info.catalog_type != CatalogType.MARGIN:
             raise ValueError(f"Catalog info `catalog_type` must equal {CatalogType.MARGIN}")
@@ -54,7 +52,6 @@ class MarginCatalog(HealpixDataset):
             catalog_path=catalog_path,
             moc=moc,
             schema=schema,
-            storage_options=storage_options,
         )
 
     def filter_by_moc(self, moc: MOC) -> Self:
@@ -70,7 +67,8 @@ class MarginCatalog(HealpixDataset):
         Returns:
             A new margin catalog with only the pixels that overlap or that have margin area that overlap with
             the moc. Note that we reset the total_rows to None, as updating would require a scan over the new
-            pixel sizes."""
+            pixel sizes.
+        """
         max_order = moc.max_order
         max_order_size = hp.nside2resol(2**max_order, arcmin=True)
         if self.catalog_info.margin_threshold > max_order_size * 60:

--- a/src/hipscat/catalog/partition_info.py
+++ b/src/hipscat/catalog/partition_info.py
@@ -8,8 +8,9 @@ from typing import List
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+from upath import UPath
 
-from hipscat.io import FilePointer, file_io, paths
+from hipscat.io import file_io, paths
 from hipscat.io.parquet_metadata import (
     read_row_group_fragments,
     row_group_stat_single_value,
@@ -48,8 +49,8 @@ class PartitionInfo:
 
     def write_to_file(
         self,
-        partition_info_file: FilePointer = None,
-        catalog_path: FilePointer = None,
+        partition_info_file: UPath = None,
+        catalog_path: UPath = None,
         storage_options: dict = None,
     ):
         """Write all partition data to CSV file.
@@ -57,7 +58,7 @@ class PartitionInfo:
         If no paths are provided, the catalog base directory from the `read_from_dir` call is used.
 
         Args:
-            partition_info_file: FilePointer to where the `partition_info.csv`
+            partition_info_file: UPath to where the `partition_info.csv`
                 file will be written.
             catalog_path: base directory for a catalog where the `partition_info.csv`
                 file will be written.
@@ -78,13 +79,13 @@ class PartitionInfo:
             self.as_dataframe(), partition_info_file, index=False, storage_options=storage_options
         )
 
-    def write_to_metadata_files(self, catalog_path: FilePointer = None, storage_options: dict = None):
+    def write_to_metadata_files(self, catalog_path: UPath = None, storage_options: dict = None):
         """Generate parquet metadata, using the known partitions.
 
         If no catalog_path is provided, the catalog base directory from the `read_from_dir` call is used.
 
         Args:
-            catalog_path (FilePointer): base path for the catalog
+            catalog_path (UPath): base path for the catalog
             storage_options (dict): dictionary that contains abstract filesystem credentials
 
         Returns:
@@ -115,7 +116,7 @@ class PartitionInfo:
         return write_parquet_metadata_for_batches(batches, catalog_path, storage_options)
 
     @classmethod
-    def read_from_dir(cls, catalog_base_dir: FilePointer, storage_options: dict = None) -> PartitionInfo:
+    def read_from_dir(cls, catalog_base_dir: UPath, storage_options: dict = None) -> PartitionInfo:
         """Read partition info from a file within a hipscat directory.
 
         This will look for a `partition_info.csv` file, and if not found, will look for
@@ -150,12 +151,12 @@ class PartitionInfo:
 
     @classmethod
     def read_from_file(
-        cls, metadata_file: FilePointer, strict: bool = False, storage_options: dict = None
+        cls, metadata_file: UPath, strict: bool = False, storage_options: dict = None
     ) -> PartitionInfo:
         """Read partition info from a `_metadata` file to create an object
 
         Args:
-            metadata_file (FilePointer): FilePointer to the `_metadata` file
+            metadata_file (UPath): UPath to the `_metadata` file
             storage_options (dict): dictionary that contains abstract filesystem credentials
             strict (bool): use strict parsing of _metadata file. this is slower, but
                 gives more helpful error messages in the case of invalid data.
@@ -167,12 +168,12 @@ class PartitionInfo:
 
     @classmethod
     def _read_from_metadata_file(
-        cls, metadata_file: FilePointer, strict: bool = False, storage_options: dict = None
+        cls, metadata_file: UPath, strict: bool = False, storage_options: dict = None
     ) -> List[HealpixPixel]:
         """Read partition info list from a `_metadata` file.
 
         Args:
-            metadata_file (FilePointer): FilePointer to the `_metadata` file
+            metadata_file (UPath): UPath to the `_metadata` file
             storage_options (dict): dictionary that contains abstract filesystem credentials
             strict (bool): use strict parsing of _metadata file. this is slower, but
                 gives more helpful error messages in the case of invalid data.
@@ -221,11 +222,11 @@ class PartitionInfo:
         return list(dict.fromkeys(pixel_list))
 
     @classmethod
-    def read_from_csv(cls, partition_info_file: FilePointer, storage_options: dict = None) -> PartitionInfo:
+    def read_from_csv(cls, partition_info_file: UPath, storage_options: dict = None) -> PartitionInfo:
         """Read partition info from a `partition_info.csv` file to create an object
 
         Args:
-            partition_info_file (FilePointer): FilePointer to the `partition_info.csv` file
+            partition_info_file (UPath): UPath to the `partition_info.csv` file
             storage_options (dict): dictionary that contains abstract filesystem credentials
 
         Returns:
@@ -234,11 +235,11 @@ class PartitionInfo:
         return cls(cls._read_from_csv(partition_info_file, storage_options))
 
     @classmethod
-    def _read_from_csv(cls, partition_info_file: FilePointer, storage_options: dict = None) -> PartitionInfo:
+    def _read_from_csv(cls, partition_info_file: UPath, storage_options: dict = None) -> PartitionInfo:
         """Read partition info from a `partition_info.csv` file to create an object
 
         Args:
-            partition_info_file (FilePointer): FilePointer to the `partition_info.csv` file
+            partition_info_file (UPath): UPath to the `partition_info.csv` file
             storage_options (dict): dictionary that contains abstract filesystem credentials
 
         Returns:

--- a/src/hipscat/catalog/partition_info.py
+++ b/src/hipscat/catalog/partition_info.py
@@ -51,7 +51,6 @@ class PartitionInfo:
         self,
         partition_info_file: UPath = None,
         catalog_path: UPath = None,
-        storage_options: dict = None,
     ):
         """Write all partition data to CSV file.
 
@@ -62,7 +61,6 @@ class PartitionInfo:
                 file will be written.
             catalog_path: base directory for a catalog where the `partition_info.csv`
                 file will be written.
-            storage_options (dict): dictionary that contains abstract filesystem credentials
 
         Raises:
             ValueError: if no path is provided, and could not be inferred.
@@ -75,18 +73,15 @@ class PartitionInfo:
             else:
                 raise ValueError("partition_info_file is required if info was not loaded from a directory")
 
-        file_io.write_dataframe_to_csv(
-            self.as_dataframe(), partition_info_file, index=False, storage_options=storage_options
-        )
+        file_io.write_dataframe_to_csv(self.as_dataframe(), partition_info_file, index=False)
 
-    def write_to_metadata_files(self, catalog_path: UPath = None, storage_options: dict = None):
+    def write_to_metadata_files(self, catalog_path: UPath = None):
         """Generate parquet metadata, using the known partitions.
 
         If no catalog_path is provided, the catalog base directory from the `read_from_dir` call is used.
 
         Args:
             catalog_path (UPath): base path for the catalog
-            storage_options (dict): dictionary that contains abstract filesystem credentials
 
         Returns:
             sum of the number of rows in the dataset.
@@ -113,10 +108,10 @@ class PartitionInfo:
             for pixel in self.get_healpix_pixels()
         ]
 
-        return write_parquet_metadata_for_batches(batches, catalog_path, storage_options)
+        return write_parquet_metadata_for_batches(batches, catalog_path)
 
     @classmethod
-    def read_from_dir(cls, catalog_base_dir: UPath, storage_options: dict = None) -> PartitionInfo:
+    def read_from_dir(cls, catalog_base_dir: UPath) -> PartitionInfo:
         """Read partition info from a file within a hipscat directory.
 
         This will look for a `partition_info.csv` file, and if not found, will look for
@@ -126,7 +121,6 @@ class PartitionInfo:
 
         Args:
             catalog_base_dir: path to the root directory of the catalog
-            storage_options (dict): dictionary that contains abstract filesystem credentials
 
         Returns:
             A `PartitionInfo` object with the data from the file
@@ -136,13 +130,11 @@ class PartitionInfo:
         """
         metadata_file = paths.get_parquet_metadata_pointer(catalog_base_dir)
         partition_info_file = paths.get_partition_info_pointer(catalog_base_dir)
-        if file_io.does_file_or_directory_exist(partition_info_file, storage_options=storage_options):
-            pixel_list = PartitionInfo._read_from_csv(partition_info_file, storage_options=storage_options)
-        elif file_io.does_file_or_directory_exist(metadata_file, storage_options=storage_options):
+        if file_io.does_file_or_directory_exist(partition_info_file):
+            pixel_list = PartitionInfo._read_from_csv(partition_info_file)
+        elif file_io.does_file_or_directory_exist(metadata_file):
             warnings.warn("Reading partitions from parquet metadata. This is typically slow.")
-            pixel_list = PartitionInfo._read_from_metadata_file(
-                metadata_file, storage_options=storage_options
-            )
+            pixel_list = PartitionInfo._read_from_metadata_file(metadata_file)
         else:
             raise FileNotFoundError(
                 f"_metadata or partition info file is required in catalog directory {catalog_base_dir}"
@@ -150,31 +142,25 @@ class PartitionInfo:
         return cls(pixel_list, catalog_base_dir)
 
     @classmethod
-    def read_from_file(
-        cls, metadata_file: UPath, strict: bool = False, storage_options: dict = None
-    ) -> PartitionInfo:
+    def read_from_file(cls, metadata_file: UPath, strict: bool = False) -> PartitionInfo:
         """Read partition info from a `_metadata` file to create an object
 
         Args:
             metadata_file (UPath): UPath to the `_metadata` file
-            storage_options (dict): dictionary that contains abstract filesystem credentials
             strict (bool): use strict parsing of _metadata file. this is slower, but
                 gives more helpful error messages in the case of invalid data.
 
         Returns:
             A `PartitionInfo` object with the data from the file
         """
-        return cls(cls._read_from_metadata_file(metadata_file, strict, storage_options))
+        return cls(cls._read_from_metadata_file(metadata_file, strict))
 
     @classmethod
-    def _read_from_metadata_file(
-        cls, metadata_file: UPath, strict: bool = False, storage_options: dict = None
-    ) -> List[HealpixPixel]:
+    def _read_from_metadata_file(cls, metadata_file: UPath, strict: bool = False) -> List[HealpixPixel]:
         """Read partition info list from a `_metadata` file.
 
         Args:
             metadata_file (UPath): UPath to the `_metadata` file
-            storage_options (dict): dictionary that contains abstract filesystem credentials
             strict (bool): use strict parsing of _metadata file. this is slower, but
                 gives more helpful error messages in the case of invalid data.
 
@@ -187,10 +173,10 @@ class PartitionInfo:
                     row_group_stat_single_value(row_group, cls.METADATA_ORDER_COLUMN_NAME),
                     row_group_stat_single_value(row_group, cls.METADATA_PIXEL_COLUMN_NAME),
                 )
-                for row_group in read_row_group_fragments(metadata_file, storage_options)
+                for row_group in read_row_group_fragments(metadata_file)
             ]
         else:
-            total_metadata = file_io.read_parquet_metadata(metadata_file, storage_options)
+            total_metadata = file_io.read_parquet_metadata(metadata_file)
             num_row_groups = total_metadata.num_row_groups
 
             first_row_group = total_metadata.row_group(0)
@@ -222,33 +208,31 @@ class PartitionInfo:
         return list(dict.fromkeys(pixel_list))
 
     @classmethod
-    def read_from_csv(cls, partition_info_file: UPath, storage_options: dict = None) -> PartitionInfo:
+    def read_from_csv(cls, partition_info_file: UPath) -> PartitionInfo:
         """Read partition info from a `partition_info.csv` file to create an object
 
         Args:
             partition_info_file (UPath): UPath to the `partition_info.csv` file
-            storage_options (dict): dictionary that contains abstract filesystem credentials
 
         Returns:
             A `PartitionInfo` object with the data from the file
         """
-        return cls(cls._read_from_csv(partition_info_file, storage_options))
+        return cls(cls._read_from_csv(partition_info_file))
 
     @classmethod
-    def _read_from_csv(cls, partition_info_file: UPath, storage_options: dict = None) -> PartitionInfo:
+    def _read_from_csv(cls, partition_info_file: UPath) -> PartitionInfo:
         """Read partition info from a `partition_info.csv` file to create an object
 
         Args:
             partition_info_file (UPath): UPath to the `partition_info.csv` file
-            storage_options (dict): dictionary that contains abstract filesystem credentials
 
         Returns:
             A `PartitionInfo` object with the data from the file
         """
-        if not file_io.does_file_or_directory_exist(partition_info_file, storage_options=storage_options):
+        if not file_io.does_file_or_directory_exist(partition_info_file):
             raise FileNotFoundError(f"No partition info found where expected: {str(partition_info_file)}")
 
-        data_frame = file_io.load_csv_to_pandas(partition_info_file, storage_options=storage_options)
+        data_frame = file_io.load_csv_to_pandas(partition_info_file)
 
         return [
             HealpixPixel(order, pixel)

--- a/src/hipscat/inspection/almanac.py
+++ b/src/hipscat/inspection/almanac.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import warnings
-from typing import Any, Dict, List, Union
+from typing import List
 
 import pandas as pd
 
@@ -33,14 +33,11 @@ class Almanac:
               catalogs.
     """
 
-    def __init__(
-        self, include_default_dir=True, dirs=None, storage_options: Union[Dict[Any, Any], None] = None
-    ):
+    def __init__(self, include_default_dir=True, dirs=None):
         """Create new almanac."""
         self.files = {}
         self.entries = {}
         self.dir_to_catalog_name = {}
-        self.storage_options = storage_options
         self._init_files(include_default_dir=include_default_dir, dirs=dirs)
         self._init_catalog_objects()
         self._init_catalog_links()
@@ -84,9 +81,7 @@ class Almanac:
                 files.append(input_path)
                 continue
 
-            path_contents = file_pointer.get_directory_contents(
-                input_path, storage_options=self.storage_options
-            )
+            path_contents = file_pointer.get_directory_contents(input_path)
             input_paths = [x for x in path_contents if str(x).endswith(".yml")]
             input_paths.sort()
             files.extend(input_paths)
@@ -101,7 +96,7 @@ class Almanac:
         in the previous steps."""
         for namespace, files in self.files.items():
             for file in files:
-                catalog_info = AlmanacInfo.from_file(file, storage_options=self.storage_options)
+                catalog_info = AlmanacInfo.from_file(file)
                 catalog_info.namespace = namespace
                 if namespace:
                     full_name = f"{namespace}:{catalog_info.catalog_name}"
@@ -217,9 +212,9 @@ class Almanac:
             linked_text = self.dir_to_catalog_name[resolved_path]
 
         resolved_name = linked_text
-        if not resolved_name in self.entries:
+        if resolved_name not in self.entries:
             resolved_name = f"{namespace}:{linked_text}"
-            if not resolved_name in self.entries:
+            if resolved_name not in self.entries:
                 return None
         return self.entries[resolved_name]
 
@@ -255,7 +250,4 @@ class Almanac:
 
         This will load the ``catalog_info.join`` and other relevant metadata files
         from disk."""
-        return read_from_hipscat(
-            self.get_almanac_info(catalog_name=catalog_name).catalog_path,
-            storage_options=self.storage_options,
-        )
+        return read_from_hipscat(self.get_almanac_info(catalog_name=catalog_name).catalog_path)

--- a/src/hipscat/inspection/almanac.py
+++ b/src/hipscat/inspection/almanac.py
@@ -85,7 +85,7 @@ class Almanac:
                 continue
 
             path_contents = file_pointer.get_directory_contents(
-                input_path, include_protocol=True, storage_options=self.storage_options
+                input_path, storage_options=self.storage_options
             )
             input_paths = [x for x in path_contents if str(x).endswith(".yml")]
             input_paths.sort()

--- a/src/hipscat/inspection/almanac_info.py
+++ b/src/hipscat/inspection/almanac_info.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import os
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Union
+from typing import List
 
 import yaml
 from typing_extensions import Self
@@ -18,7 +18,6 @@ class AlmanacInfo:
     """Container for parsed almanac information."""
 
     file_path: str = ""
-    storage_options: Union[Dict[Any, Any], None] = field(default_factory=dict)
     namespace: str = ""
     catalog_path: str = ""
     catalog_name: str = ""
@@ -75,13 +74,10 @@ class AlmanacInfo:
         return default_dir
 
     @classmethod
-    def from_catalog_dir(
-        cls, catalog_base_dir: str, storage_options: Union[Dict[Any, Any], None] = None
-    ) -> Self:
+    def from_catalog_dir(cls, catalog_base_dir: str) -> Self:
         """Create almanac information from the catalog information found at the target directory"""
         catalog_info = catalog_info_factory.from_catalog_dir(
-            catalog_base_dir=file_io.get_upath(catalog_base_dir),
-            storage_options=storage_options,
+            catalog_base_dir=file_io.get_upath(catalog_base_dir)
         )
         args = {
             "catalog_path": catalog_base_dir,
@@ -93,12 +89,12 @@ class AlmanacInfo:
         return cls(**args)
 
     @classmethod
-    def from_file(cls, file: str, storage_options: Union[Dict[Any, Any], None] = None) -> Self:
+    def from_file(cls, file: str) -> Self:
         """Create almanac information from an almanac file."""
         _, fmt = os.path.splitext(file)
         if fmt != ".yml":
             raise ValueError(f"Unsupported file format {fmt}")
-        metadata = file_io.file_io.read_yaml(file, storage_options=storage_options)
+        metadata = file_io.file_io.read_yaml(file)
         return cls(**metadata)
 
     def write_to_file(
@@ -106,7 +102,6 @@ class AlmanacInfo:
         directory=None,
         default_dir=True,
         fmt="yml",
-        storage_options: Union[Dict[Any, Any], None] = None,
     ):
         """Write the almanac to an almanac file"""
         if default_dir and directory:
@@ -117,7 +112,7 @@ class AlmanacInfo:
 
         file_path = file_io.get_upath(directory) / f"{self.catalog_name}.{fmt}"
 
-        if file_io.does_file_or_directory_exist(file_path, storage_options=storage_options):
+        if file_io.does_file_or_directory_exist(file_path):
             raise ValueError(f"File already exists at path {str(file_path)}")
 
         args = {
@@ -142,4 +137,4 @@ class AlmanacInfo:
         else:
             raise ValueError(f"Unsupported file format {fmt}")
 
-        file_io.write_string_to_file(file_path, encoded_string, storage_options=storage_options)
+        file_io.write_string_to_file(file_path, encoded_string)

--- a/src/hipscat/inspection/almanac_info.py
+++ b/src/hipscat/inspection/almanac_info.py
@@ -80,7 +80,7 @@ class AlmanacInfo:
     ) -> Self:
         """Create almanac information from the catalog information found at the target directory"""
         catalog_info = catalog_info_factory.from_catalog_dir(
-            catalog_base_dir=file_io.get_file_pointer_from_path(catalog_base_dir),
+            catalog_base_dir=file_io.get_upath(catalog_base_dir),
             storage_options=storage_options,
         )
         args = {
@@ -115,9 +115,8 @@ class AlmanacInfo:
         if default_dir:
             directory = AlmanacInfo.get_default_dir()
 
-        file_path = file_io.append_paths_to_pointer(
-            file_io.get_file_pointer_from_path(directory), f"{self.catalog_name}.{fmt}"
-        )
+        file_path = file_io.get_upath(directory) / f"{self.catalog_name}.{fmt}"
+
         if file_io.does_file_or_directory_exist(file_path, storage_options=storage_options):
             raise ValueError(f"File already exists at path {str(file_path)}")
 

--- a/src/hipscat/inspection/visualize_catalog.py
+++ b/src/hipscat/inspection/visualize_catalog.py
@@ -3,7 +3,7 @@
 NB: Testing validity of generated plots is currently not tested in our unit test suite.
 """
 
-from typing import Any, Dict, List, Union
+from typing import List
 
 import healpy as hp
 import matplotlib.colors as mcolors
@@ -16,7 +16,7 @@ from hipscat.io import file_io, paths
 from hipscat.pixel_math import HealpixPixel
 
 
-def _read_point_map(catalog_base_dir, storage_options: Union[Dict[Any, Any], None] = None):
+def _read_point_map(catalog_base_dir):
     """Read the object spatial distribution information from a healpix FITS file.
 
     Args:
@@ -26,9 +26,7 @@ def _read_point_map(catalog_base_dir, storage_options: Union[Dict[Any, Any], Non
         corresponds to the number of objects found at the healpix pixel.
     """
     map_file_pointer = paths.get_point_map_file_pointer(catalog_base_dir)
-    print("map_file_pointer", map_file_pointer)
-    print("so", map_file_pointer.storage_options)
-    return file_io.read_fits_image(map_file_pointer, storage_options=storage_options)
+    return file_io.read_fits_image(map_file_pointer)
 
 
 def plot_points(catalog: Catalog, projection="moll", **kwargs):
@@ -44,7 +42,7 @@ def plot_points(catalog: Catalog, projection="moll", **kwargs):
     """
     if not catalog.on_disk:
         raise ValueError("on disk catalog required for point-wise visualization")
-    point_map = _read_point_map(catalog.catalog_base_dir, storage_options=catalog.storage_options)
+    point_map = _read_point_map(catalog.catalog_base_dir)
     _plot_healpix_map(point_map, projection, f"Catalog point density map - {catalog.catalog_name}", **kwargs)
 
 

--- a/src/hipscat/inspection/visualize_catalog.py
+++ b/src/hipscat/inspection/visualize_catalog.py
@@ -26,6 +26,8 @@ def _read_point_map(catalog_base_dir, storage_options: Union[Dict[Any, Any], Non
         corresponds to the number of objects found at the healpix pixel.
     """
     map_file_pointer = paths.get_point_map_file_pointer(catalog_base_dir)
+    print("map_file_pointer", map_file_pointer)
+    print("so", map_file_pointer.storage_options)
     return file_io.read_fits_image(map_file_pointer, storage_options=storage_options)
 
 

--- a/src/hipscat/io/__init__.py
+++ b/src/hipscat/io/__init__.py
@@ -1,6 +1,5 @@
 """Utilities for reading and writing catalog files"""
 
-from .file_io import FilePointer, get_file_pointer_from_path
 from .parquet_metadata import (
     read_row_group_fragments,
     row_group_stat_single_value,

--- a/src/hipscat/io/__init__.py
+++ b/src/hipscat/io/__init__.py
@@ -8,7 +8,6 @@ from .parquet_metadata import (
 )
 from .paths import (
     create_hive_directory_name,
-    create_hive_parquet_file_name,
     get_catalog_info_pointer,
     get_common_metadata_pointer,
     get_parquet_metadata_pointer,

--- a/src/hipscat/io/file_io/__init__.py
+++ b/src/hipscat/io/file_io/__init__.py
@@ -3,7 +3,6 @@ from .file_io import (
     load_csv_to_pandas,
     load_csv_to_pandas_generator,
     load_json_file,
-    load_parquet_to_pandas,
     load_text_file,
     make_directory,
     read_fits_image,
@@ -18,16 +17,11 @@ from .file_io import (
     write_string_to_file,
 )
 from .file_pointer import (
-    FilePointer,
     append_paths_to_pointer,
     directory_has_contents,
     does_file_or_directory_exist,
     find_files_matching_path,
-    get_basename_from_filepointer,
     get_directory_contents,
-    get_file_pointer_for_fs,
-    get_file_pointer_from_path,
-    get_file_protocol,
+    get_upath,
     is_regular_file,
-    strip_leading_slash_for_pyarrow,
 )

--- a/src/hipscat/io/file_io/file_io.py
+++ b/src/hipscat/io/file_io/file_io.py
@@ -11,13 +11,14 @@ import pyarrow.dataset as pds
 import pyarrow.parquet as pq
 import yaml
 from pyarrow.dataset import Dataset
+from upath import UPath
 
 import hipscat.pixel_math.healpix_shim as hp
-from hipscat.io.file_io.file_pointer import FilePointer, get_fs, strip_leading_slash_for_pyarrow
+from hipscat.io.file_io.file_pointer import get_upath
 
 
 def make_directory(
-    file_pointer: FilePointer, exist_ok: bool = False, storage_options: Union[Dict[Any, Any], None] = None
+    file_pointer: UPath, exist_ok: bool = False, storage_options: Union[Dict[Any, Any], None] = None
 ):
     """Make a directory at a given file pointer
 
@@ -33,8 +34,9 @@ def make_directory(
     Raises:
         OSError
     """
-    file_system, file_pointer = get_fs(file_pointer, storage_options=storage_options)
-    file_system.makedirs(file_pointer, exist_ok=exist_ok)
+    # file_system, file_pointer = get_fs(file_pointer, storage_options=storage_options)
+    file_pointer = get_upath(file_pointer)
+    file_pointer.mkdir(parents=True, exist_ok=exist_ok)
 
 
 def unnest_headers_for_pandas(storage_options: Union[Dict[Any, Any], None]) -> Union[Dict[Any, Any], None]:
@@ -50,8 +52,17 @@ def unnest_headers_for_pandas(storage_options: Union[Dict[Any, Any], None]) -> U
     return storage_options
 
 
+def _rmdir_recursive(directory):
+    for item in directory.iterdir():
+        if item.is_dir():
+            _rmdir_recursive(item)
+        else:
+            item.unlink()
+    directory.rmdir()
+
+
 def remove_directory(
-    file_pointer: FilePointer, ignore_errors=False, storage_options: Union[Dict[Any, Any], None] = None
+    file_pointer: UPath, ignore_errors=False, storage_options: Union[Dict[Any, Any], None] = None
 ):
     """Remove a directory, and all contents, recursively.
 
@@ -60,20 +71,20 @@ def remove_directory(
         ignore_errors: if True errors resulting from failed removals will be ignored
         storage_options: dictionary that contains abstract filesystem credentials
     """
-
-    file_system, file_pointer = get_fs(file_pointer, storage_options)
+    file_pointer = get_upath(file_pointer)
+    # file_system, file_pointer = get_fs(file_pointer, storage_options)
     if ignore_errors:
         try:
-            file_system.rm(file_pointer, recursive=True)
+            _rmdir_recursive(file_pointer)
         except Exception:  # pylint: disable=broad-except
             # fsspec doesn't have a "ignore_errors" field in the rm method
             pass
     else:
-        file_system.rm(file_pointer, recursive=True)
+        _rmdir_recursive(file_pointer)
 
 
 def write_string_to_file(
-    file_pointer: FilePointer,
+    file_pointer: UPath,
     string: str,
     encoding: str = "utf-8",
     storage_options: Union[Dict[Any, Any], None] = None,
@@ -86,13 +97,14 @@ def write_string_to_file(
         encoding: Default: 'utf-8', encoding method to write to file with
         storage_options: dictionary that contains abstract filesystem credentials
     """
-    file_system, file_pointer = get_fs(file_pointer, storage_options)
-    with file_system.open(file_pointer, "w", encoding=encoding) as _file:
+    file_pointer = get_upath(file_pointer)
+    # file_system, file_pointer = get_fs(file_pointer, storage_options)
+    with file_pointer.open("w", encoding=encoding) as _file:
         _file.write(string)
 
 
 def load_text_file(
-    file_pointer: FilePointer, encoding: str = "utf-8", storage_options: Union[Dict[Any, Any], None] = None
+    file_pointer: UPath, encoding: str = "utf-8", storage_options: Union[Dict[Any, Any], None] = None
 ):
     """Load a text file content to a list of strings.
 
@@ -103,15 +115,16 @@ def load_text_file(
     Returns:
         text contents of file.
     """
-    file_system, file_pointer = get_fs(file_pointer, storage_options)
-    with file_system.open(file_pointer, "r", encoding=encoding) as _text_file:
+    file_pointer = get_upath(file_pointer)
+    # file_system, file_pointer = get_fs(file_pointer, storage_options)
+    with file_pointer.open("r", encoding=encoding) as _text_file:
         text_file = _text_file.readlines()
 
     return text_file
 
 
 def load_json_file(
-    file_pointer: FilePointer, encoding: str = "utf-8", storage_options: Union[Dict[Any, Any], None] = None
+    file_pointer: UPath, encoding: str = "utf-8", storage_options: Union[Dict[Any, Any], None] = None
 ) -> dict:
     """Load a json file to a dictionary
 
@@ -122,17 +135,17 @@ def load_json_file(
     Returns:
         dictionary of key value pairs loaded from the JSON file
     """
-
+    file_pointer = get_upath(file_pointer)
     json_dict = None
-    file_system, file_pointer = get_fs(file_pointer, storage_options)
-    with file_system.open(file_pointer, "r", encoding=encoding) as json_file:
+    # file_system, file_pointer = get_fs(file_pointer, storage_options)
+    with file_pointer.open("r", encoding=encoding) as json_file:
         json_dict = json.load(json_file)
 
     return json_dict
 
 
 def load_csv_to_pandas(
-    file_pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None, **kwargs
+    file_pointer: UPath, storage_options: Union[Dict[Any, Any], None] = None, **kwargs
 ) -> pd.DataFrame:
     """Load a csv file to a pandas dataframe
 
@@ -143,14 +156,15 @@ def load_csv_to_pandas(
     Returns:
         pandas dataframe loaded from CSV
     """
-    file_system, file_pointer = get_fs(file_pointer, storage_options=storage_options)
-    with file_system.open(file_pointer, "r") as csv_file:
+    file_pointer = get_upath(file_pointer)
+    # file_system, file_pointer = get_fs(file_pointer, storage_options=storage_options)
+    with file_pointer.open("r") as csv_file:
         frame = pd.read_csv(csv_file, **kwargs)
     return frame
 
 
 def load_csv_to_pandas_generator(
-    file_pointer: FilePointer,
+    file_pointer: UPath,
     chunksize=10_000,
     *,
     storage_options: Union[Dict[Any, Any], None] = None,
@@ -165,31 +179,16 @@ def load_csv_to_pandas_generator(
     Returns:
         pandas dataframe loaded from CSV
     """
-    file_system, file_pointer = get_fs(file_pointer, storage_options=storage_options)
-    with file_system.open(file_pointer, "r", **kwargs) as csv_file:
+    file_pointer = get_upath(file_pointer)
+    # file_system, file_pointer = get_fs(file_pointer, storage_options=storage_options)
+    with file_pointer.open("r", **kwargs) as csv_file:
         with pd.read_csv(csv_file, chunksize=chunksize, **kwargs) as reader:
             yield from reader
 
 
-def load_parquet_to_pandas(
-    file_pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None, **kwargs
-) -> pd.DataFrame:
-    """Load a parquet file to a pandas dataframe
-
-    Args:
-        file_pointer: location of parquet file to load
-        storage_options: dictionary that contains abstract filesystem credentials
-        **kwargs: arguments to pass to pandas `read_parquet` loading method
-    Returns:
-        pandas dataframe loaded from parquet
-    """
-    pd_storage_option = unnest_headers_for_pandas(storage_options)
-    return pd.read_parquet(file_pointer, storage_options=pd_storage_option, **kwargs)
-
-
 def write_dataframe_to_csv(
     dataframe: pd.DataFrame,
-    file_pointer: FilePointer,
+    file_pointer: UPath,
     storage_options: Union[Dict[Any, Any], None] = None,
     **kwargs,
 ):
@@ -215,11 +214,12 @@ def write_dataframe_to_parquet(
         file_pointer: location of file to write to
         storage_options: dictionary that contains abstract filesystem credentials
     """
+    file_pointer = get_upath(file_pointer)
     dataframe.to_parquet(file_pointer, storage_options=storage_options)
 
 
 def read_parquet_metadata(
-    file_pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None, **kwargs
+    file_pointer: UPath, storage_options: Union[Dict[Any, Any], None] = None, **kwargs
 ) -> pq.FileMetaData:
     """Read FileMetaData from footer of a single Parquet file.
 
@@ -228,17 +228,16 @@ def read_parquet_metadata(
         storage_options: dictionary that contains abstract filesystem credentials
         **kwargs: additional arguments to be passed to pyarrow.parquet.read_metadata
     """
-    file_system, file_pointer = get_fs(file_pointer=file_pointer, storage_options=storage_options)
-
-    file_pointer = strip_leading_slash_for_pyarrow(file_pointer, protocol=file_system.protocol)
-
-    parquet_file = pq.read_metadata(file_pointer, filesystem=file_system, **kwargs)
+    file_pointer = get_upath(file_pointer)
+    if file_pointer is None or not file_pointer.exists():
+        raise FileNotFoundError("Parquet file does not exist")
+    parquet_file = pq.read_metadata(file_pointer.path, filesystem=file_pointer.fs, **kwargs)
     return parquet_file
 
 
 def read_parquet_dataset(
-    source: FilePointer, storage_options: Union[Dict[Any, Any], None] = None, **kwargs
-) -> Tuple[FilePointer, Dataset]:
+    source: UPath, storage_options: Union[Dict[Any, Any], None] = None, **kwargs
+) -> Tuple[UPath, Dataset]:
     """Read parquet dataset from directory pointer or list of files.
 
     Note that pyarrow.dataset reads require that directory pointers don't contain a
@@ -256,14 +255,19 @@ def read_parquet_dataset(
         Tuple containing a path to the dataset (that is formatted for pyarrow ingestion)
         and the dataset read from disk.
     """
+
     # pyarrow.dataset requires the pointer not lead with a slash
     if pd.api.types.is_list_like(source) and len(source) > 0:
         sample_pointer = source[0]
-        file_system, sample_pointer = get_fs(file_pointer=sample_pointer, storage_options=storage_options)
-        source = [strip_leading_slash_for_pyarrow(path, file_system.protocol) for path in source]
+        sample_pointer = get_upath(sample_pointer)
+        file_system = sample_pointer.fs
+        # file_system, sample_pointer = get_fs(file_pointer=sample_pointer, storage_options=storage_options)
+        source = [get_upath(path) for path in source]
     else:
-        file_system, source = get_fs(file_pointer=source, storage_options=storage_options)
-        source = strip_leading_slash_for_pyarrow(source, file_system.protocol)
+        # file_system, source = get_fs(file_pointer=source, storage_options=storage_options)
+        # source = strip_leading_slash_for_pyarrow(source, file_system.protocol)
+        source = get_upath(source)
+        file_system = source.fs
 
     dataset = pds.dataset(
         source,
@@ -271,12 +275,12 @@ def read_parquet_dataset(
         format="parquet",
         **kwargs,
     )
-    return (source, dataset)
+    return (str(source), dataset)
 
 
 def write_parquet_metadata(
     schema: Any,
-    file_pointer: FilePointer,
+    file_pointer: UPath,
     metadata_collector: list | None = None,
     storage_options: Union[Dict[Any, Any], None] = None,
     **kwargs,
@@ -290,16 +294,16 @@ def write_parquet_metadata(
         storage_options: dictionary that contains abstract filesystem credentials
         **kwargs: additional arguments to be passed to pyarrow.parquet.write_metadata
     """
+    file_pointer = get_upath(file_pointer)
+    # file_system, file_pointer = get_fs(file_pointer=file_pointer, storage_options=storage_options)
 
-    file_system, file_pointer = get_fs(file_pointer=file_pointer, storage_options=storage_options)
-
-    file_pointer = strip_leading_slash_for_pyarrow(file_pointer, protocol=file_system.protocol)
+    # file_pointer = strip_leading_slash_for_pyarrow(file_pointer, protocol=file_system.protocol)
     pq.write_metadata(
-        schema, file_pointer, metadata_collector=metadata_collector, filesystem=file_system, **kwargs
+        schema, file_pointer, metadata_collector=metadata_collector, filesystem=file_pointer.fs, **kwargs
     )
 
 
-def read_fits_image(map_file_pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None):
+def read_fits_image(map_file_pointer: UPath, storage_options: Union[Dict[Any, Any], None] = None):
     """Read the object spatial distribution information from a healpix FITS file.
 
     Args:
@@ -309,9 +313,10 @@ def read_fits_image(map_file_pointer: FilePointer, storage_options: Union[Dict[A
         one-dimensional numpy array of long integers where the
         value at each index corresponds to the number of objects found at the healpix pixel.
     """
-    file_system, map_file_pointer = get_fs(file_pointer=map_file_pointer, storage_options=storage_options)
+    # file_system, map_file_pointer = get_fs(file_pointer=map_file_pointer, storage_options=storage_options)
+    map_file_pointer = get_upath(map_file_pointer)
     with tempfile.NamedTemporaryFile() as _tmp_file:
-        with file_system.open(map_file_pointer, "rb") as _map_file:
+        with map_file_pointer.open("rb") as _map_file:
             map_data = _map_file.read()
             _tmp_file.write(map_data)
             map_fits_image = hp.read_map(_tmp_file.name, nest=True, h=True)
@@ -328,7 +333,7 @@ def read_fits_image(map_file_pointer: FilePointer, storage_options: Union[Dict[A
 
 
 def write_fits_image(
-    histogram: np.ndarray, map_file_pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
+    histogram: np.ndarray, map_file_pointer: UPath, storage_options: Union[Dict[Any, Any], None] = None
 ):
     """Write the object spatial distribution information to a healpix FITS file.
 
@@ -338,48 +343,51 @@ def write_fits_image(
         file_pointer: location of file to be written
         storage_options: dictionary that contains abstract filesystem credentials
     """
-    file_system, map_file_pointer = get_fs(file_pointer=map_file_pointer, storage_options=storage_options)
+    map_file_pointer = get_upath(map_file_pointer)
+    # file_system, map_file_pointer = get_fs(file_pointer=map_file_pointer, storage_options=storage_options)
     with tempfile.NamedTemporaryFile() as _tmp_file:
-        with file_system.open(map_file_pointer, "wb") as _map_file:
+        with map_file_pointer.open("wb") as _map_file:
             hp.write_map(_tmp_file.name, histogram, overwrite=True, dtype=np.int64, nest=True)
             _map_file.write(_tmp_file.read())
 
 
-def read_yaml(file_handle: FilePointer, storage_options: Union[Dict[Any, Any], None] = None):
+def read_yaml(file_handle: UPath, storage_options: Union[Dict[Any, Any], None] = None):
     """Reads yaml file from filesystem.
 
     Args:
         file_handle: location of yaml file
         storage_options: dictionary that contains abstract filesystem credentials
     """
-    file_system, file_handle = get_fs(file_pointer=file_handle, storage_options=storage_options)
-    with file_system.open(file_handle, "r", encoding="utf-8") as _file:
+    file_handle = get_upath(file_handle)
+    with file_handle.open("r", encoding="utf-8") as _file:
         metadata = yaml.safe_load(_file)
     return metadata
 
 
-def delete_file(file_handle: FilePointer, storage_options: Union[Dict[Any, Any], None] = None):
+def delete_file(file_handle: UPath, storage_options: Union[Dict[Any, Any], None] = None):
     """Deletes file from filesystem.
 
     Args:
         file_handle: location of file pointer
         storage_options: dictionary that contains filesystem credentials
     """
-    file_system, file_handle = get_fs(file_pointer=file_handle, storage_options=storage_options)
-    file_system.rm(file_handle)
+    file_handle = get_upath(file_handle)
+    # file_system, file_handle = get_fs(file_pointer=file_handle, storage_options=storage_options)
+    file_handle.unlink()
 
 
 def read_parquet_file_to_pandas(
-    file_pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None, **kwargs
+    file_pointer: UPath, storage_options: Union[Dict[Any, Any], None] = None, **kwargs
 ) -> pd.DataFrame:
     """Reads a parquet file to a pandas DataFrame
 
     Args:
-        file_pointer (FilePointer): File Pointer to a parquet file
+        file_pointer (UPath): File Pointer to a parquet file
         **kwargs: Additional arguments to pass to pandas read_parquet method
 
     Returns:
         Pandas DataFrame with the data from the parquet file
     """
-    pd_storage_option = unnest_headers_for_pandas(storage_options)
-    return pd.read_parquet(file_pointer, storage_options=pd_storage_option, **kwargs)
+    file_pointer = get_upath(file_pointer)
+    with file_pointer.open("rb", **kwargs) as parquet_file:
+        return pd.read_parquet(parquet_file, **kwargs)

--- a/src/hipscat/io/file_io/file_pointer.py
+++ b/src/hipscat/io/file_io/file_pointer.py
@@ -1,7 +1,5 @@
-import os
-from typing import Any, Dict, List, NewType, Tuple, Union
+from typing import List
 
-import fsspec
 from upath import UPath
 
 
@@ -29,50 +27,39 @@ def append_paths_to_pointer(pointer: UPath, *paths: str) -> UPath:
     return pointer.joinpath(*paths)
 
 
-def does_file_or_directory_exist(pointer: UPath, storage_options: Union[Dict[Any, Any], None] = None) -> bool:
+def does_file_or_directory_exist(pointer: UPath) -> bool:
     """Checks if a file or directory exists for a given file pointer
 
     Args:
         pointer: File Pointer to check if file or directory exists at
-        storage_options: dictionary that contains abstract filesystem credentials
 
     Returns:
         True if file or directory at `pointer` exists, False if not
     """
-    # file_system, pointer = pointer, storage_options)
-    # return file_system.exists(pointer)
     pointer = get_upath(pointer)
     return pointer.exists()
 
 
-def is_regular_file(pointer: UPath, storage_options: Union[Dict[Any, Any], None] = None) -> bool:
+def is_regular_file(pointer: UPath) -> bool:
     """Checks if a regular file (NOT a directory) exists for a given file pointer.
 
     Args:
         pointer: File Pointer to check if a regular file
-        storage_options: dictionary that contains abstract filesystem credentials
 
     Returns:
         True if regular file at `pointer` exists, False if not or is a directory
     """
-    # file_system, pointer = get_fs(pointer, storage_options)
-    # return file_system.isfile(pointer)
     pointer = get_upath(pointer)
     return pointer.is_file()
 
 
-def find_files_matching_path(
-    pointer: UPath,
-    *paths: str,
-    storage_options: Union[Dict[Any, Any], None] = None,
-) -> List[UPath]:
+def find_files_matching_path(pointer: UPath, *paths: str) -> List[UPath]:
     """Find files or directories matching the provided path parts.
 
     Args:
         pointer: base File Pointer in which to find contents
         paths: any number of directory names optionally followed by a file name.
             directory or file names may be replaced with `*` as a matcher.
-        storage_options: dictionary that contains abstract filesystem credentials
     Returns:
         New file pointers to files found matching the path
     """
@@ -93,30 +80,26 @@ def find_files_matching_path(
     return contents
 
 
-def directory_has_contents(pointer: UPath, storage_options: Union[Dict[Any, Any], None] = None) -> bool:
+def directory_has_contents(pointer: UPath) -> bool:
     """Checks if a directory already has some contents (any files or subdirectories)
 
     Args:
         pointer: File Pointer to check for existing contents
-        storage_options: dictionary that contains abstract filesystem credentials
 
     Returns:
         True if there are any files or subdirectories below this directory.
     """
     pointer = get_upath(pointer)
-    return len(find_files_matching_path(pointer, "*", storage_options=storage_options)) > 0
+    return len(find_files_matching_path(pointer, "*")) > 0
 
 
-def get_directory_contents(
-    pointer: UPath, storage_options: Union[Dict[Any, Any], None] = None
-) -> List[UPath]:
+def get_directory_contents(pointer: UPath) -> List[UPath]:
     """Finds all files and directories in the specified directory.
 
     NB: This is not recursive, and will return only the first level of directory contents.
 
     Args:
         pointer: File Pointer in which to find contents
-        storage_options: dictionary that contains abstract filesystem credentials
 
     Returns:
         New file pointers to files or subdirectories below this directory.

--- a/src/hipscat/io/file_io/file_pointer.py
+++ b/src/hipscat/io/file_io/file_pointer.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
+from pathlib import Path
 from typing import List
 
 from upath import UPath
 
 
-def get_upath(path) -> UPath:
+def get_upath(path: str | Path | UPath) -> UPath:
     """Returns a file pointer from a path string"""
     if not path:
         return None

--- a/src/hipscat/io/file_io/file_pointer.py
+++ b/src/hipscat/io/file_io/file_pointer.py
@@ -2,127 +2,19 @@ import os
 from typing import Any, Dict, List, NewType, Tuple, Union
 
 import fsspec
-
-FilePointer = NewType("FilePointer", str)
-"""Unified type for references to files."""
+from upath import UPath
 
 
-def get_file_protocol(pointer: FilePointer) -> str:
-    """Method to parse filepointer for the filesystem protocol.
-    If it doesn't follow the pattern of protocol://pathway/to/file, then it
-    assumes that it is a localfilesystem.
-
-    Args:
-        pointer: filesystem pathway pointer
-    """
-
-    if not isinstance(pointer, str):
-        pointer = str(pointer)
-
-    protocol = fsspec.utils.get_protocol(pointer)
-
-    return protocol
-
-
-def get_fs(
-    file_pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
-) -> Tuple[fsspec.filesystem, FilePointer]:
-    """Create the abstract filesystem
-
-    Args:
-        file_pointer: filesystem pathway
-        storage_options: dictionary that contains abstract filesystem credentials
-    Raises:
-        ImportError: if environment cannot import necessary libraries for
-            fsspec filesystems.
-    """
-    if storage_options is None:
-        storage_options = {}
-    protocol = get_file_protocol(file_pointer)
-    file_pointer = get_file_pointer_for_fs(protocol, file_pointer)
-
-    try:
-        file_system = fsspec.filesystem(protocol, **storage_options)
-    except ImportError as error:
-        raise ImportError from error
-
-    return file_system, file_pointer
-
-
-def get_file_pointer_for_fs(protocol: str, file_pointer: FilePointer) -> FilePointer:
-    """Creates the filepathway from the file_pointer.
-
-    This will strip the protocol so that the file_pointer can be accessed from
-    the filesystem:
-
-        - abfs filesystems DO NOT require the account_name in the pathway
-        - s3 filesystems DO require the account_name/container name in the pathway
-
-    Args:
-        protocol: str filesytem protocol, file, abfs, or s3
-        file_pointer: filesystem pathway
-    """
-    if not isinstance(file_pointer, str):
-        file_pointer = str(file_pointer)
-
-    if "file" in protocol:
-        # return the entire filepath for local files
-        if "file://" in file_pointer:
-            split_pointer = file_pointer.split("file://")[1]
-        else:
-            split_pointer = file_pointer
-    elif protocol.startswith("http"):
-        # http/https should include the protocol in the file path
-        split_pointer = file_pointer  # don't split
-    else:
-        split_pointer = file_pointer.split(f"{protocol}://")[1]
-
-    return FilePointer(split_pointer)
-
-
-def get_full_file_pointer(path: str, protocol_path: str) -> FilePointer:
-    """Rebuilds the file_pointer with the protocol and account name if required"""
-    protocol = get_file_protocol(protocol_path)
-    if not path.startswith(protocol):
-        path = f"{protocol}://{path}"
-    return FilePointer(path)
-
-
-def get_file_pointer_from_path(path: str, include_protocol: str = None) -> FilePointer:
+def get_upath(path) -> UPath:
     """Returns a file pointer from a path string"""
-    if include_protocol:
-        path = get_full_file_pointer(path, include_protocol)
-    return FilePointer(path)
+    if not path:
+        return None
+    if isinstance(path, UPath):
+        return path
+    return UPath(path)
 
 
-def get_basename_from_filepointer(pointer: FilePointer) -> str:
-    """Returns the base name of a regular file. May return empty string if the file is a directory.
-
-    Args:
-        pointer: `FilePointer` object to find a basename within
-
-    Returns:
-        string representation of the basename of a file.
-    """
-    return os.path.basename(pointer)
-
-
-def strip_leading_slash_for_pyarrow(pointer: FilePointer, protocol: str) -> FilePointer:
-    """Strips the leading slash for pyarrow read/write functions.
-    This is required for pyarrow's underlying filesystem abstraction.
-
-    Args:
-        pointer: `FilePointer` object
-
-    Returns:
-        New file pointer with leading slash removed.
-    """
-    if "file" not in protocol and str(pointer).startswith("/"):
-        pointer = FilePointer(str(pointer).replace("/", "", 1))
-    return pointer
-
-
-def append_paths_to_pointer(pointer: FilePointer, *paths: str) -> FilePointer:
+def append_paths_to_pointer(pointer: UPath, *paths: str) -> UPath:
     """Append directories and/or a file name to a specified file pointer.
 
     Args:
@@ -133,12 +25,11 @@ def append_paths_to_pointer(pointer: FilePointer, *paths: str) -> FilePointer:
     Returns:
         New file pointer to path given by joining given pointer and path names
     """
-    return FilePointer(os.path.join(pointer, *paths))
+    pointer = get_upath(pointer)
+    return pointer.joinpath(*paths)
 
 
-def does_file_or_directory_exist(
-    pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
-) -> bool:
+def does_file_or_directory_exist(pointer: UPath, storage_options: Union[Dict[Any, Any], None] = None) -> bool:
     """Checks if a file or directory exists for a given file pointer
 
     Args:
@@ -148,11 +39,13 @@ def does_file_or_directory_exist(
     Returns:
         True if file or directory at `pointer` exists, False if not
     """
-    file_system, pointer = get_fs(pointer, storage_options)
-    return file_system.exists(pointer)
+    # file_system, pointer = pointer, storage_options)
+    # return file_system.exists(pointer)
+    pointer = get_upath(pointer)
+    return pointer.exists()
 
 
-def is_regular_file(pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None) -> bool:
+def is_regular_file(pointer: UPath, storage_options: Union[Dict[Any, Any], None] = None) -> bool:
     """Checks if a regular file (NOT a directory) exists for a given file pointer.
 
     Args:
@@ -162,40 +55,45 @@ def is_regular_file(pointer: FilePointer, storage_options: Union[Dict[Any, Any],
     Returns:
         True if regular file at `pointer` exists, False if not or is a directory
     """
-    file_system, pointer = get_fs(pointer, storage_options)
-    return file_system.isfile(pointer)
+    # file_system, pointer = get_fs(pointer, storage_options)
+    # return file_system.isfile(pointer)
+    pointer = get_upath(pointer)
+    return pointer.is_file()
 
 
 def find_files_matching_path(
-    pointer: FilePointer,
+    pointer: UPath,
     *paths: str,
-    include_protocol=False,
     storage_options: Union[Dict[Any, Any], None] = None,
-) -> List[FilePointer]:
+) -> List[UPath]:
     """Find files or directories matching the provided path parts.
 
     Args:
         pointer: base File Pointer in which to find contents
         paths: any number of directory names optionally followed by a file name.
             directory or file names may be replaced with `*` as a matcher.
-        include_protocol: boolean on whether or not to include the filesystem protocol in the
-            returned directory contents
         storage_options: dictionary that contains abstract filesystem credentials
     Returns:
         New file pointers to files found matching the path
     """
-    matcher = append_paths_to_pointer(pointer, *paths)
-    file_system, _ = get_fs(pointer, storage_options)
+    pointer = get_upath(pointer)
 
-    contents = [get_file_pointer_from_path(x) for x in file_system.glob(matcher)]
+    if len(paths) == 0:
+        return [pointer]
 
-    if include_protocol:
-        contents = [get_full_file_pointer(x, protocol_path=pointer) for x in contents]
+    matcher = pointer.fs.sep.join(paths)
+    contents = []
+    for child in pointer.rglob(matcher):
+        contents.append(child)
 
+    if len(contents) == 0:
+        return []
+
+    contents.sort()
     return contents
 
 
-def directory_has_contents(pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None) -> bool:
+def directory_has_contents(pointer: UPath, storage_options: Union[Dict[Any, Any], None] = None) -> bool:
     """Checks if a directory already has some contents (any files or subdirectories)
 
     Args:
@@ -205,33 +103,31 @@ def directory_has_contents(pointer: FilePointer, storage_options: Union[Dict[Any
     Returns:
         True if there are any files or subdirectories below this directory.
     """
+    pointer = get_upath(pointer)
     return len(find_files_matching_path(pointer, "*", storage_options=storage_options)) > 0
 
 
 def get_directory_contents(
-    pointer: FilePointer, include_protocol=False, storage_options: Union[Dict[Any, Any], None] = None
-) -> List[FilePointer]:
+    pointer: UPath, storage_options: Union[Dict[Any, Any], None] = None
+) -> List[UPath]:
     """Finds all files and directories in the specified directory.
 
     NB: This is not recursive, and will return only the first level of directory contents.
 
     Args:
         pointer: File Pointer in which to find contents
-        include_protocol: boolean on whether or not to include the filesystem protocol in the
-            returned directory contents
         storage_options: dictionary that contains abstract filesystem credentials
 
     Returns:
         New file pointers to files or subdirectories below this directory.
     """
-    file_system, file_pointer = get_fs(pointer, storage_options)
-    contents = file_system.listdir(file_pointer)
-    contents = [FilePointer(x["name"]) for x in contents]
+    pointer = get_upath(pointer)
+    contents = []
+    for child in pointer.iterdir():
+        contents.append(child)
 
     if len(contents) == 0:
         return []
 
     contents.sort()
-    if include_protocol:
-        contents = [get_full_file_pointer(x, protocol_path=pointer) for x in contents]
     return contents

--- a/src/hipscat/io/parquet_metadata.py
+++ b/src/hipscat/io/parquet_metadata.py
@@ -1,16 +1,15 @@
 """Utility functions for handling parquet metadata files"""
 
 import tempfile
-from typing import Any, Dict, List, Union
+from typing import List
 
 import numpy as np
 import pyarrow as pa
 import pyarrow.dataset as pds
 import pyarrow.parquet as pq
+from upath import UPath
 
 from hipscat.io import file_io, paths
-
-# from hipscat.io.file_io.file_pointer import get_fs, strip_leading_slash_for_pyarrow
 from hipscat.io.file_io.file_pointer import get_upath
 from hipscat.pixel_math.healpix_pixel import INVALID_PIXEL, HealpixPixel
 from hipscat.pixel_math.healpix_pixel_function import get_pixel_argsort
@@ -75,10 +74,9 @@ def get_healpix_pixel_from_metadata(
 
 
 def write_parquet_metadata(
-    catalog_path: str,
+    catalog_path: UPath,
     order_by_healpix=True,
-    output_path: str = None,
-    storage_options: Union[Dict[Any, Any], None] = None,
+    output_path: UPath = None,
 ):
     """Generate parquet metadata, using the already-partitioned parquet files
     for this catalog.
@@ -90,7 +88,6 @@ def write_parquet_metadata(
         catalog_path (str): base path for the catalog
         order_by_healpix (bool): use False if the dataset is not to be reordered by
             breadth-first healpix pixel (e.g. secondary indexes)
-        storage_options: dictionary that contains abstract filesystem credentials
         output_path (str): base path for writing out metadata files
             defaults to `catalog_path` if unspecified
 
@@ -103,9 +100,9 @@ def write_parquet_metadata(
         "_metadata",
     ]
 
+    catalog_path = get_upath(catalog_path)
     (dataset_path, dataset) = file_io.read_parquet_dataset(
         catalog_path,
-        storage_options=storage_options,
         ignore_prefixes=ignore_prefixes,
         exclude_invalid_files=True,
     )
@@ -114,12 +111,11 @@ def write_parquet_metadata(
     healpix_pixels = []
     total_rows = 0
 
-    for hips_file in dataset.files:
-        hips_file_pointer = file_io.get_upath(hips_file)
-        single_metadata = file_io.read_parquet_metadata(hips_file_pointer, storage_options=storage_options)
+    for single_file in dataset.files:
+        relative_path = single_file[len(dataset_path) + 1 :]
+        single_metadata = file_io.read_parquet_metadata(catalog_path / relative_path)
 
         # Users must set the file path of each chunk before combining the metadata.
-        relative_path = hips_file[len(dataset_path) :]
         single_metadata.set_file_path(relative_path)
 
         if order_by_healpix:
@@ -146,17 +142,12 @@ def write_parquet_metadata(
         metadata_file_pointer,
         metadata_collector=metadata_collector,
         write_statistics=True,
-        storage_options=storage_options,
     )
-    file_io.write_parquet_metadata(
-        dataset.schema, common_metadata_file_pointer, storage_options=storage_options
-    )
+    file_io.write_parquet_metadata(dataset.schema, common_metadata_file_pointer)
     return total_rows
 
 
-def write_parquet_metadata_for_batches(
-    batches: List[List[pa.RecordBatch]], output_path: str = None, storage_options: dict = None
-):
+def write_parquet_metadata_for_batches(batches: List[List[pa.RecordBatch]], output_path: str = None):
     """Write parquet metadata files for some pyarrow table batches.
     This writes the batches to a temporary parquet dataset using local storage, and
     generates the metadata for the partitioned catalog parquet files.
@@ -166,7 +157,6 @@ def write_parquet_metadata_for_batches(
             into tables by the inner list.
         output_path (str): base path for writing out metadata files
             defaults to `catalog_path` if unspecified
-        storage_options: dictionary that contains abstract filesystem credentials
 
     Returns:
         sum of the number of rows in the dataset.
@@ -176,22 +166,19 @@ def write_parquet_metadata_for_batches(
         for batch_list in batches:
             temp_info_table = pa.Table.from_batches(batch_list)
             pq.write_to_dataset(temp_info_table, temp_pq_file)
-        return write_parquet_metadata(temp_pq_file, storage_options=storage_options, output_path=output_path)
+        return write_parquet_metadata(temp_pq_file, output_path=output_path)
 
 
-def read_row_group_fragments(metadata_file: str, storage_options: dict = None):
+def read_row_group_fragments(metadata_file: str):
     """Generator for metadata fragment row groups in a parquet metadata file.
 
     Args:
         metadata_file (str): path to `_metadata` file.
-        storage_options: dictionary that contains abstract filesystem credentials
     """
     metadata_file = get_upath(metadata_file)
-    if not file_io.is_regular_file(metadata_file, storage_options=storage_options):
+    if not file_io.is_regular_file(metadata_file):
         metadata_file = paths.get_parquet_metadata_pointer(metadata_file)
 
-    # file_system, file_pointer = get_fs(file_pointer=metadata_file, storage_options=storage_options)
-    # file_pointer = strip_leading_slash_for_pyarrow(file_pointer, file_system.protocol)
     dataset = pds.parquet_dataset(metadata_file, filesystem=metadata_file.fs)
 
     for frag in dataset.get_fragments():

--- a/src/hipscat/io/paths.py
+++ b/src/hipscat/io/paths.py
@@ -7,8 +7,9 @@ from typing import Dict, List
 from urllib.parse import urlencode
 
 from fsspec.implementations.http import HTTPFileSystem
+from upath import UPath
 
-from hipscat.io.file_io.file_pointer import FilePointer, append_paths_to_pointer, get_fs
+from hipscat.io.file_io.file_pointer import get_upath
 from hipscat.pixel_math.healpix_pixel import INVALID_PIXEL, HealpixPixel
 
 ORDER_DIRECTORY_PREFIX = "Norder"
@@ -28,11 +29,11 @@ POINT_MAP_FILENAME = "point_map.fits"
 
 
 def pixel_directory(
-    catalog_base_dir: FilePointer,
+    catalog_base_dir: UPath,
     pixel_order: int,
     pixel_number: int | None = None,
     directory_number: int | None = None,
-) -> FilePointer:
+) -> UPath:
     """Create path pointer for a pixel directory. This will not create the directory.
 
     One of pixel_number or directory_number is required. The directory name will
@@ -45,12 +46,12 @@ def pixel_directory(
         (pixel_number/10000)*10000
 
     Args:
-        catalog_base_dir (FilePointer): base directory of the catalog (includes catalog name)
+        catalog_base_dir (UPath): base directory of the catalog (includes catalog name)
         pixel_order (int): the healpix order of the pixel
         directory_number (int): directory number
         pixel_number (int): the healpix pixel
     Returns:
-        FilePointer directory name
+        UPath directory name
     """
     norder = int(pixel_order)
     if directory_number is not None:
@@ -90,11 +91,11 @@ def get_healpix_from_path(path: str) -> HealpixPixel:
 
 
 def pixel_catalog_files(
-    catalog_base_dir: FilePointer,
+    catalog_base_dir: UPath,
     pixels: List[HealpixPixel],
     query_params: Dict | None = None,
     storage_options: Dict | None = None,
-) -> List[FilePointer]:
+) -> List[UPath]:
     """Create a list of path *pointers* for pixel catalog files. This will not create the directory
     or files.
 
@@ -107,25 +108,28 @@ def pixel_catalog_files(
         (pixel_number/10000)*10000
 
     Args:
-        catalog_base_dir (FilePointer): base directory of the catalog (includes catalog name)
+        catalog_base_dir (UPath): base directory of the catalog (includes catalog name)
         pixels (List[HealpixPixel]): the healpix pixels to create pointers to
         query_params (dict): Params to append to URL. Ex: {'cols': ['ra', 'dec'], 'fltrs': ['r>=10', 'g<18']}
         storage_options (dict): the storage options for the file system to target when generating the paths
 
-    Returns (List[FilePointer]):
+    Returns (List[str]):
         A list of paths to the pixels, in the same order as the input pixel list.
     """
-    fs, _ = get_fs(catalog_base_dir, storage_options)
-    base_path_stripped = catalog_base_dir.removesuffix(fs.sep)
+    catalog_base_dir = get_upath(catalog_base_dir)
+    fs = catalog_base_dir.fs
+    base_path = str(catalog_base_dir)
+    if not base_path.endswith(fs.sep):
+        base_path += fs.sep
 
     url_params = ""
     if isinstance(fs, HTTPFileSystem) and query_params:
         url_params = dict_to_query_urlparams(query_params)
 
     return [
-        fs.sep.join(
+        base_path
+        + fs.sep.join(
             [
-                base_path_stripped,
                 f"{ORDER_DIRECTORY_PREFIX}={pixel.order}",
                 f"{DIR_DIRECTORY_PREFIX}={pixel.dir}",
                 f"{PIXEL_DIRECTORY_PREFIX}={pixel.pixel}.parquet" + url_params,
@@ -163,7 +167,9 @@ def dict_to_query_urlparams(query_params: Dict | None = None) -> str:
     return url_params
 
 
-def pixel_catalog_file(catalog_base_dir: FilePointer, pixel_order: int, pixel_number: int) -> FilePointer:
+def pixel_catalog_file(
+    catalog_base_dir: UPath, pixel: HealpixPixel, query_params: Dict | None = None
+) -> UPath:
     """Create path *pointer* for a pixel catalog file. This will not create the directory
     or file.
 
@@ -176,16 +182,23 @@ def pixel_catalog_file(catalog_base_dir: FilePointer, pixel_order: int, pixel_nu
         (pixel_number/10000)*10000
 
     Args:
-        catalog_base_dir (FilePointer): base directory of the catalog (includes catalog name)
-        pixel_order (int): the healpix order of the pixel
-        pixel_number (int): the healpix pixel
+        catalog_base_dir (UPath): base directory of the catalog (includes catalog name)
+        pixel (HealpixPixel): the healpix pixel to create path to
+        query_params (dict): Params to append to URL. Ex: {'cols': ['ra', 'dec'], 'fltrs': ['r>=10', 'g<18']}
     Returns:
         string catalog file name
     """
-    return create_hive_parquet_file_name(
-        catalog_base_dir,
-        [ORDER_DIRECTORY_PREFIX, DIR_DIRECTORY_PREFIX, PIXEL_DIRECTORY_PREFIX],
-        [int(pixel_order), int(pixel_number / 10_000) * 10_000, int(pixel_number)],
+    catalog_base_dir = get_upath(catalog_base_dir)
+
+    url_params = ""
+    if isinstance(catalog_base_dir.fs, HTTPFileSystem) and query_params:
+        url_params = dict_to_query_urlparams(query_params)
+
+    return (
+        catalog_base_dir
+        / f"{ORDER_DIRECTORY_PREFIX}={pixel.order}"
+        / f"{DIR_DIRECTORY_PREFIX}={pixel.dir}"
+        / f"{PIXEL_DIRECTORY_PREFIX}={pixel.pixel}.parquet{url_params}"
     )
 
 
@@ -198,7 +211,7 @@ def create_hive_directory_name(base_dir, partition_token_names, partition_token_
         <catalog_base_dir>/<name_1>=<value_1>/.../<name_n>=<value_n>
 
     Args:
-        catalog_base_dir (FilePointer): base directory of the catalog (includes catalog name)
+        catalog_base_dir (UPath): base directory of the catalog (includes catalog name)
         partition_token_names (list[string]): list of partition name parts.
         partition_token_values (list[string]): list of partition values that
             correspond to the token name parts.
@@ -206,7 +219,7 @@ def create_hive_directory_name(base_dir, partition_token_names, partition_token_
     partition_tokens = [
         f"{name}={value}" for name, value in zip(partition_token_names, partition_token_values)
     ]
-    return append_paths_to_pointer(base_dir, *partition_tokens)
+    return get_upath(base_dir).joinpath(*partition_tokens)
 
 
 def create_hive_parquet_file_name(base_dir, partition_token_names, partition_token_values):
@@ -217,7 +230,7 @@ def create_hive_parquet_file_name(base_dir, partition_token_names, partition_tok
         <catalog_base_dir>/<name_1>=<value_1>/.../<name_n>=<value_n>.parquet
 
     Args:
-        catalog_base_dir (FilePointer): base directory of the catalog (includes catalog name)
+        catalog_base_dir (UPath): base directory of the catalog (includes catalog name)
         partition_token_names (list[string]): list of partition name parts.
         partition_token_values (list[string]): list of partition values that
             correspond to the token name parts.
@@ -225,10 +238,12 @@ def create_hive_parquet_file_name(base_dir, partition_token_names, partition_tok
     partition_tokens = [
         f"{name}={value}" for name, value in zip(partition_token_names, partition_token_values)
     ]
-    return f"{append_paths_to_pointer(base_dir, *partition_tokens)}.parquet"
+    partition_tokens[-1] = f"{partition_tokens[-1]}.parquet"
+
+    return get_upath(base_dir).joinpath(*partition_tokens)
 
 
-def get_catalog_info_pointer(catalog_base_dir: FilePointer) -> FilePointer:
+def get_catalog_info_pointer(catalog_base_dir: UPath) -> UPath:
     """Get file pointer to `catalog_info.json` metadata file
 
     Args:
@@ -236,10 +251,10 @@ def get_catalog_info_pointer(catalog_base_dir: FilePointer) -> FilePointer:
     Returns:
         File Pointer to the catalog's `catalog_info.json` file
     """
-    return append_paths_to_pointer(catalog_base_dir, CATALOG_INFO_FILENAME)
+    return get_upath(catalog_base_dir) / CATALOG_INFO_FILENAME
 
 
-def get_partition_info_pointer(catalog_base_dir: FilePointer) -> FilePointer:
+def get_partition_info_pointer(catalog_base_dir: UPath) -> UPath:
     """Get file pointer to `partition_info.csv` metadata file
 
     Args:
@@ -247,10 +262,10 @@ def get_partition_info_pointer(catalog_base_dir: FilePointer) -> FilePointer:
     Returns:
         File Pointer to the catalog's `partition_info.csv` file
     """
-    return append_paths_to_pointer(catalog_base_dir, PARTITION_INFO_FILENAME)
+    return get_upath(catalog_base_dir) / PARTITION_INFO_FILENAME
 
 
-def get_provenance_pointer(catalog_base_dir: FilePointer) -> FilePointer:
+def get_provenance_pointer(catalog_base_dir: UPath) -> UPath:
     """Get file pointer to `provenance_info.json` metadata file
 
     Args:
@@ -258,10 +273,10 @@ def get_provenance_pointer(catalog_base_dir: FilePointer) -> FilePointer:
     Returns:
         File Pointer to the catalog's `provenance_info.json` file
     """
-    return append_paths_to_pointer(catalog_base_dir, PROVENANCE_INFO_FILENAME)
+    return get_upath(catalog_base_dir) / PROVENANCE_INFO_FILENAME
 
 
-def get_common_metadata_pointer(catalog_base_dir: FilePointer) -> FilePointer:
+def get_common_metadata_pointer(catalog_base_dir: UPath) -> UPath:
     """Get file pointer to `_common_metadata` parquet metadata file
 
     Args:
@@ -269,10 +284,10 @@ def get_common_metadata_pointer(catalog_base_dir: FilePointer) -> FilePointer:
     Returns:
         File Pointer to the catalog's `_common_metadata` file
     """
-    return append_paths_to_pointer(catalog_base_dir, PARQUET_COMMON_METADATA_FILENAME)
+    return get_upath(catalog_base_dir) / PARQUET_COMMON_METADATA_FILENAME
 
 
-def get_parquet_metadata_pointer(catalog_base_dir: FilePointer) -> FilePointer:
+def get_parquet_metadata_pointer(catalog_base_dir: UPath) -> UPath:
     """Get file pointer to `_metadata` parquet metadata file
 
     Args:
@@ -280,10 +295,10 @@ def get_parquet_metadata_pointer(catalog_base_dir: FilePointer) -> FilePointer:
     Returns:
         File Pointer to the catalog's `_metadata` file
     """
-    return append_paths_to_pointer(catalog_base_dir, PARQUET_METADATA_FILENAME)
+    return get_upath(catalog_base_dir) / PARQUET_METADATA_FILENAME
 
 
-def get_point_map_file_pointer(catalog_base_dir: FilePointer) -> FilePointer:
+def get_point_map_file_pointer(catalog_base_dir: UPath) -> UPath:
     """Get file pointer to `point_map.fits` FITS image file.
 
     Args:
@@ -291,10 +306,10 @@ def get_point_map_file_pointer(catalog_base_dir: FilePointer) -> FilePointer:
     Returns:
         File Pointer to the catalog's `point_map.fits` FITS image file.
     """
-    return append_paths_to_pointer(catalog_base_dir, POINT_MAP_FILENAME)
+    return get_upath(catalog_base_dir) / POINT_MAP_FILENAME
 
 
-def get_partition_join_info_pointer(catalog_base_dir: FilePointer) -> FilePointer:
+def get_partition_join_info_pointer(catalog_base_dir: UPath) -> UPath:
     """Get file pointer to `partition_join_info.csv` association metadata file
 
     Args:
@@ -302,4 +317,4 @@ def get_partition_join_info_pointer(catalog_base_dir: FilePointer) -> FilePointe
     Returns:
         File Pointer to the catalog's `partition_join_info.csv` association metadata file
     """
-    return append_paths_to_pointer(catalog_base_dir, PARTITION_JOIN_INFO_FILENAME)
+    return get_upath(catalog_base_dir) / PARTITION_JOIN_INFO_FILENAME

--- a/src/hipscat/io/paths.py
+++ b/src/hipscat/io/paths.py
@@ -94,7 +94,6 @@ def pixel_catalog_files(
     catalog_base_dir: UPath,
     pixels: List[HealpixPixel],
     query_params: Dict | None = None,
-    storage_options: Dict | None = None,
 ) -> List[UPath]:
     """Create a list of path *pointers* for pixel catalog files. This will not create the directory
     or files.
@@ -111,7 +110,6 @@ def pixel_catalog_files(
         catalog_base_dir (UPath): base directory of the catalog (includes catalog name)
         pixels (List[HealpixPixel]): the healpix pixels to create pointers to
         query_params (dict): Params to append to URL. Ex: {'cols': ['ra', 'dec'], 'fltrs': ['r>=10', 'g<18']}
-        storage_options (dict): the storage options for the file system to target when generating the paths
 
     Returns (List[str]):
         A list of paths to the pixels, in the same order as the input pixel list.

--- a/src/hipscat/io/paths.py
+++ b/src/hipscat/io/paths.py
@@ -219,28 +219,6 @@ def create_hive_directory_name(base_dir, partition_token_names, partition_token_
     ]
     return get_upath(base_dir).joinpath(*partition_tokens)
 
-
-def create_hive_parquet_file_name(base_dir, partition_token_names, partition_token_values):
-    """Create path *pointer* for a single parquet with hive partitioning naming.
-
-    The file name will have the form of::
-
-        <catalog_base_dir>/<name_1>=<value_1>/.../<name_n>=<value_n>.parquet
-
-    Args:
-        catalog_base_dir (UPath): base directory of the catalog (includes catalog name)
-        partition_token_names (list[string]): list of partition name parts.
-        partition_token_values (list[string]): list of partition values that
-            correspond to the token name parts.
-    """
-    partition_tokens = [
-        f"{name}={value}" for name, value in zip(partition_token_names, partition_token_values)
-    ]
-    partition_tokens[-1] = f"{partition_tokens[-1]}.parquet"
-
-    return get_upath(base_dir).joinpath(*partition_tokens)
-
-
 def get_catalog_info_pointer(catalog_base_dir: UPath) -> UPath:
     """Get file pointer to `catalog_info.json` metadata file
 

--- a/src/hipscat/io/paths.py
+++ b/src/hipscat/io/paths.py
@@ -219,6 +219,7 @@ def create_hive_directory_name(base_dir, partition_token_names, partition_token_
     ]
     return get_upath(base_dir).joinpath(*partition_tokens)
 
+
 def get_catalog_info_pointer(catalog_base_dir: UPath) -> UPath:
     """Get file pointer to `catalog_info.json` metadata file
 

--- a/src/hipscat/io/paths.py
+++ b/src/hipscat/io/paths.py
@@ -29,7 +29,7 @@ POINT_MAP_FILENAME = "point_map.fits"
 
 
 def pixel_directory(
-    catalog_base_dir: UPath,
+    catalog_base_dir: UPath | None,
     pixel_order: int,
     pixel_number: int | None = None,
     directory_number: int | None = None,
@@ -91,7 +91,7 @@ def get_healpix_from_path(path: str) -> HealpixPixel:
 
 
 def pixel_catalog_files(
-    catalog_base_dir: UPath,
+    catalog_base_dir: UPath | None,
     pixels: List[HealpixPixel],
     query_params: Dict | None = None,
 ) -> List[UPath]:
@@ -166,7 +166,7 @@ def dict_to_query_urlparams(query_params: Dict | None = None) -> str:
 
 
 def pixel_catalog_file(
-    catalog_base_dir: UPath, pixel: HealpixPixel, query_params: Dict | None = None
+    catalog_base_dir: UPath | None, pixel: HealpixPixel, query_params: Dict | None = None
 ) -> UPath:
     """Create path *pointer* for a pixel catalog file. This will not create the directory
     or file.

--- a/src/hipscat/io/validation.py
+++ b/src/hipscat/io/validation.py
@@ -2,13 +2,14 @@ import warnings
 from typing import Any, Dict, Union
 
 import numpy as np
+from upath import UPath
 
 import hipscat.pixel_math.healpix_shim as hp
 from hipscat.catalog.dataset.catalog_info_factory import from_catalog_dir
 from hipscat.catalog.partition_info import PartitionInfo
 from hipscat.io import get_common_metadata_pointer, get_parquet_metadata_pointer, get_partition_info_pointer
 from hipscat.io.file_io import read_parquet_dataset
-from hipscat.io.file_io.file_pointer import FilePointer, is_regular_file
+from hipscat.io.file_io.file_pointer import is_regular_file
 from hipscat.io.paths import get_healpix_from_path
 from hipscat.loaders import read_from_hipscat
 from hipscat.pixel_math.healpix_pixel import INVALID_PIXEL
@@ -17,7 +18,7 @@ from hipscat.pixel_math.healpix_pixel_function import sort_pixels
 
 # pylint: disable=too-many-statements,too-many-locals
 def is_valid_catalog(
-    pointer: FilePointer,
+    pointer: UPath,
     strict: bool = False,
     fail_fast: bool = False,
     verbose: bool = True,
@@ -26,7 +27,7 @@ def is_valid_catalog(
     """Checks if a catalog is valid for a given base catalog pointer
 
     Args:
-        pointer (FilePointer): pointer to base catalog directory
+        pointer (UPath): pointer to base catalog directory
         strict (bool): should we perform additional checking that every optional
             file exists, and contains valid, consistent information.
         fail_fast (bool): if performing strict checks, should we return at the first
@@ -159,11 +160,11 @@ def is_valid_catalog(
     return is_valid
 
 
-def is_catalog_info_valid(pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None) -> bool:
+def is_catalog_info_valid(pointer: UPath, storage_options: Union[Dict[Any, Any], None] = None) -> bool:
     """Checks if catalog_info is valid for a given base catalog pointer
 
     Args:
-        pointer (FilePointer): pointer to base catalog directory
+        pointer (UPath): pointer to base catalog directory
         storage_options: dictionary that contains abstract filesystem credentials
 
     Returns:
@@ -177,13 +178,11 @@ def is_catalog_info_valid(pointer: FilePointer, storage_options: Union[Dict[Any,
     return True
 
 
-def is_partition_info_valid(
-    pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
-) -> bool:
+def is_partition_info_valid(pointer: UPath, storage_options: Union[Dict[Any, Any], None] = None) -> bool:
     """Checks if partition_info is valid for a given base catalog pointer
 
     Args:
-        pointer (FilePointer): pointer to base catalog directory
+        pointer (UPath): pointer to base catalog directory
         storage_options: dictionary that contains abstract filesystem credentials
 
     Returns:
@@ -194,11 +193,11 @@ def is_partition_info_valid(
     return partition_info_exists
 
 
-def is_metadata_valid(pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None) -> bool:
+def is_metadata_valid(pointer: UPath, storage_options: Union[Dict[Any, Any], None] = None) -> bool:
     """Checks if _metadata is valid for a given base catalog pointer
 
     Args:
-        pointer (FilePointer): pointer to base catalog directory
+        pointer (UPath): pointer to base catalog directory
         storage_options: dictionary that contains abstract filesystem credentials
 
     Returns:
@@ -209,13 +208,11 @@ def is_metadata_valid(pointer: FilePointer, storage_options: Union[Dict[Any, Any
     return metadata_file_exists
 
 
-def is_common_metadata_valid(
-    pointer: FilePointer, storage_options: Union[Dict[Any, Any], None] = None
-) -> bool:
+def is_common_metadata_valid(pointer: UPath, storage_options: Union[Dict[Any, Any], None] = None) -> bool:
     """Checks if _common_metadata is valid for a given base catalog pointer
 
     Args:
-        pointer (FilePointer): pointer to base catalog directory
+        pointer (UPath): pointer to base catalog directory
         storage_options: dictionary that contains abstract filesystem credentials
 
     Returns:

--- a/src/hipscat/io/write_metadata.py
+++ b/src/hipscat/io/write_metadata.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Union
 
 import numpy as np
 import pandas as pd
+from upath import UPath
 
 from hipscat.io import file_io, paths
 from hipscat.pixel_math.healpix_pixel import HealpixPixel
@@ -37,7 +38,7 @@ class HipscatEncoder(json.JSONEncoder):
 
 def write_json_file(
     metadata_dictionary: dict,
-    file_pointer: file_io.FilePointer,
+    file_pointer: UPath,
     storage_options: Union[Dict[Any, Any], None] = None,
 ):
     """Convert metadata_dictionary to a json string and print to file.
@@ -66,7 +67,7 @@ def write_catalog_info(catalog_base_dir, dataset_info, storage_options: Union[Di
 
 
 def write_provenance_info(
-    catalog_base_dir: file_io.FilePointer,
+    catalog_base_dir: UPath,
     dataset_info,
     tool_args: dict,
     storage_options: Union[Dict[Any, Any], None] = None,
@@ -92,7 +93,7 @@ def write_provenance_info(
 
 
 def write_partition_info(
-    catalog_base_dir: file_io.FilePointer,
+    catalog_base_dir: UPath,
     destination_healpix_pixel_map: dict,
     storage_options: Union[Dict[Any, Any], None] = None,
 ):
@@ -135,6 +136,6 @@ def write_fits_map(catalog_path, histogram: np.ndarray, storage_options: Union[D
             value at each index corresponds to the number of objects found at the healpix pixel.
         storage_options: dictionary that contains abstract filesystem credentials
     """
-    catalog_base_dir = file_io.get_file_pointer_from_path(catalog_path)
+    catalog_base_dir = file_io.get_upath(catalog_path)
     map_file_pointer = paths.get_point_map_file_pointer(catalog_base_dir)
     file_io.write_fits_image(histogram, map_file_pointer, storage_options=storage_options)

--- a/src/hipscat/loaders/read_from_hipscat.py
+++ b/src/hipscat/loaders/read_from_hipscat.py
@@ -47,7 +47,7 @@ def read_from_hipscat(
 def _read_dataset_class_from_metadata(
     catalog_base_path: str, storage_options: dict | None = None
 ) -> CatalogType:
-    catalog_base_dir = io.file_io.get_file_pointer_from_path(catalog_base_path)
+    catalog_base_dir = io.file_io.get_upath(catalog_base_path)
     catalog_info_path = io.paths.get_catalog_info_pointer(catalog_base_dir)
     catalog_info = BaseCatalogInfo.read_from_metadata_file(catalog_info_path, storage_options=storage_options)
     return catalog_info.catalog_type

--- a/src/hipscat/loaders/read_from_hipscat.py
+++ b/src/hipscat/loaders/read_from_hipscat.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import Type
+from pathlib import Path
+from typing import Type, Union
+
+from upath import UPath
 
 from hipscat import io
 from hipscat.catalog import AssociationCatalog, Catalog, CatalogType, Dataset, MarginCatalog
@@ -16,7 +19,7 @@ CATALOG_TYPE_TO_CLASS = {
 }
 
 
-def read_from_hipscat(catalog_path: str, catalog_type: CatalogType | None = None) -> Dataset:
+def read_from_hipscat(catalog_path: str | Path | UPath, catalog_type: CatalogType | None = None) -> Dataset:
     """Reads a HiPSCat Catalog from a HiPSCat directory
 
     Args:

--- a/src/hipscat/loaders/read_from_hipscat.py
+++ b/src/hipscat/loaders/read_from_hipscat.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Type, Union
+from typing import Type
 
 from upath import UPath
 

--- a/src/hipscat/loaders/read_from_hipscat.py
+++ b/src/hipscat/loaders/read_from_hipscat.py
@@ -16,11 +16,7 @@ CATALOG_TYPE_TO_CLASS = {
 }
 
 
-def read_from_hipscat(
-    catalog_path: str,
-    catalog_type: CatalogType | None = None,
-    storage_options: dict | None = None,
-) -> Dataset:
+def read_from_hipscat(catalog_path: str, catalog_type: CatalogType | None = None) -> Dataset:
     """Reads a HiPSCat Catalog from a HiPSCat directory
 
     Args:
@@ -30,26 +26,21 @@ def read_from_hipscat(
             cannot allow a return type specified by a loaded value, so to use the correct return
             type for type checking, the type of the catalog can be specified here. Use by specifying
             the hipscat class for that catalog.
-        storage_options (dict): dictionary that contains abstract filesystem credentials
 
     Returns:
         The initialized catalog object
     """
     catalog_type_to_use = (
-        _read_dataset_class_from_metadata(catalog_path, storage_options=storage_options)
-        if catalog_type is None
-        else catalog_type
+        _read_dataset_class_from_metadata(catalog_path) if catalog_type is None else catalog_type
     )
     loader = _get_loader_from_catalog_type(catalog_type_to_use)
-    return loader.read_from_hipscat(catalog_path, storage_options=storage_options)
+    return loader.read_from_hipscat(catalog_path)
 
 
-def _read_dataset_class_from_metadata(
-    catalog_base_path: str, storage_options: dict | None = None
-) -> CatalogType:
+def _read_dataset_class_from_metadata(catalog_base_path: str) -> CatalogType:
     catalog_base_dir = io.file_io.get_upath(catalog_base_path)
     catalog_info_path = io.paths.get_catalog_info_pointer(catalog_base_dir)
-    catalog_info = BaseCatalogInfo.read_from_metadata_file(catalog_info_path, storage_options=storage_options)
+    catalog_info = BaseCatalogInfo.read_from_metadata_file(catalog_info_path)
     return catalog_info.catalog_type
 
 

--- a/src/hipscat/pixel_math/box_filter.py
+++ b/src/hipscat/pixel_math/box_filter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Iterable, List, Tuple
+from collections.abc import Iterable
+from typing import List, Tuple
 
 import numpy as np
 from mocpy import MOC

--- a/src/hipscat/pixel_math/hipscat_id.py
+++ b/src/hipscat/pixel_math/hipscat_id.py
@@ -4,7 +4,7 @@ Compute the hipscat index field
 This index is defined as a 64-bit integer which has two parts:
     - healpix pixel (at order 19)
     - incrementing counter (within same healpix, for uniqueness)
-    
+
 ::
 
     |------------------------------------------|-------------------|

--- a/src/hipscat/pixel_tree/pixel_tree.py
+++ b/src/hipscat/pixel_tree/pixel_tree.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import List, Sequence
+from collections.abc import Sequence
+from typing import List
 
 import numpy as np
 from mocpy import MOC

--- a/tests/hipscat/catalog/association_catalog/test_association_catalog.py
+++ b/tests/hipscat/catalog/association_catalog/test_association_catalog.py
@@ -57,7 +57,7 @@ def test_read_from_file(
 
     assert isinstance(catalog, AssociationCatalog)
     assert catalog.on_disk
-    assert catalog.catalog_path == str(association_catalog_path)
+    assert catalog.catalog_path == association_catalog_path
     assert len(catalog.get_join_pixels()) == 4
     assert len(catalog.get_healpix_pixels()) == 1
     pd.testing.assert_frame_equal(catalog.get_join_pixels(), association_catalog_join_pixels)

--- a/tests/hipscat/catalog/association_catalog/test_association_catalog_info.py
+++ b/tests/hipscat/catalog/association_catalog/test_association_catalog_info.py
@@ -22,8 +22,7 @@ def test_str(association_catalog_info_data):
 
 
 def test_read_from_file(association_catalog_info_file, assert_catalog_info_matches_dict):
-    cat_info_fp = file_io.get_file_pointer_from_path(association_catalog_info_file)
-    catalog_info = AssociationCatalogInfo.read_from_metadata_file(cat_info_fp)
+    catalog_info = AssociationCatalogInfo.read_from_metadata_file(association_catalog_info_file)
     for column in [
         "catalog_name",
         "catalog_type",

--- a/tests/hipscat/catalog/association_catalog/test_association_catalog_info.py
+++ b/tests/hipscat/catalog/association_catalog/test_association_catalog_info.py
@@ -5,7 +5,6 @@ import pytest
 
 from hipscat.catalog.association_catalog.association_catalog_info import AssociationCatalogInfo
 from hipscat.catalog.catalog_type import CatalogType
-from hipscat.io import file_io
 
 
 def test_association_catalog_info(association_catalog_info_data, assert_catalog_info_matches_dict):

--- a/tests/hipscat/catalog/association_catalog/test_partition_join_info.py
+++ b/tests/hipscat/catalog/association_catalog/test_partition_join_info.py
@@ -20,8 +20,7 @@ def test_wrong_columns(association_catalog_join_pixels):
 
 
 def test_read_from_metadata(association_catalog_join_pixels, association_catalog_path):
-    file_pointer = file_io.get_file_pointer_from_path(association_catalog_path / "_metadata")
-    info = PartitionJoinInfo.read_from_file(file_pointer)
+    info = PartitionJoinInfo.read_from_file(association_catalog_path / "_metadata")
     pd.testing.assert_frame_equal(info.data_frame, association_catalog_join_pixels)
 
 
@@ -90,8 +89,7 @@ def test_metadata_file_round_trip(association_catalog_join_pixels, tmp_path):
     total_rows = info.write_to_metadata_files(tmp_path)
     assert total_rows == 4
 
-    file_pointer = file_io.get_file_pointer_from_path(tmp_path / "_metadata")
-    new_info = PartitionJoinInfo.read_from_file(file_pointer)
+    new_info = PartitionJoinInfo.read_from_file(tmp_path / "_metadata")
     pd.testing.assert_frame_equal(new_info.data_frame, association_catalog_join_pixels)
 
 
@@ -100,22 +98,18 @@ def test_csv_file_round_trip(association_catalog_join_pixels, tmp_path):
     pd.testing.assert_frame_equal(info.data_frame, association_catalog_join_pixels)
     info.write_to_csv(tmp_path)
 
-    file_pointer = file_io.get_file_pointer_from_path(tmp_path / "partition_join_info.csv")
-    new_info = PartitionJoinInfo.read_from_csv(file_pointer)
+    new_info = PartitionJoinInfo.read_from_csv(tmp_path / "partition_join_info.csv")
     pd.testing.assert_frame_equal(new_info.data_frame, association_catalog_join_pixels)
 
 
 def test_read_from_csv(association_catalog_partition_join_file, association_catalog_join_pixels):
-    file_pointer = file_io.get_file_pointer_from_path(association_catalog_partition_join_file)
-    info = PartitionJoinInfo.read_from_csv(file_pointer)
+    info = PartitionJoinInfo.read_from_csv(association_catalog_partition_join_file)
     pd.testing.assert_frame_equal(info.data_frame, association_catalog_join_pixels)
 
 
 def test_read_from_missing_file(tmp_path):
-    wrong_path = tmp_path / "wrong"
-    file_pointer = file_io.get_file_pointer_from_path(wrong_path)
     with pytest.raises(FileNotFoundError):
-        PartitionJoinInfo.read_from_csv(file_pointer)
+        PartitionJoinInfo.read_from_csv(tmp_path / "wrong")
 
 
 def test_load_partition_info_from_dir_and_write(tmp_path, association_catalog_join_pixels):

--- a/tests/hipscat/catalog/association_catalog/test_partition_join_info.py
+++ b/tests/hipscat/catalog/association_catalog/test_partition_join_info.py
@@ -2,7 +2,6 @@ import pandas as pd
 import pytest
 
 from hipscat.catalog.association_catalog.partition_join_info import PartitionJoinInfo
-from hipscat.io import file_io
 from hipscat.pixel_math.healpix_pixel import HealpixPixel
 
 

--- a/tests/hipscat/catalog/dataset/test_base_catalog_info.py
+++ b/tests/hipscat/catalog/dataset/test_base_catalog_info.py
@@ -3,7 +3,6 @@ import json
 import pytest
 
 from hipscat.catalog.dataset.base_catalog_info import BaseCatalogInfo
-from hipscat.io import file_io
 
 
 def test_fields_init(base_catalog_info_data, assert_catalog_info_matches_dict):

--- a/tests/hipscat/catalog/dataset/test_base_catalog_info.py
+++ b/tests/hipscat/catalog/dataset/test_base_catalog_info.py
@@ -34,8 +34,7 @@ def test_str(base_catalog_info_data):
 
 
 def test_read_from_file(base_catalog_info_file, assert_catalog_info_matches_dict):
-    base_cat_info_fp = file_io.get_file_pointer_from_path(base_catalog_info_file)
-    catalog_info = BaseCatalogInfo.read_from_metadata_file(base_cat_info_fp)
+    catalog_info = BaseCatalogInfo.read_from_metadata_file(base_catalog_info_file)
     with open(base_catalog_info_file, "r", encoding="utf-8") as cat_info_file:
         catalog_info_json = json.load(cat_info_file)
         assert_catalog_info_matches_dict(catalog_info, catalog_info_json)

--- a/tests/hipscat/catalog/dataset/test_dataset.py
+++ b/tests/hipscat/catalog/dataset/test_dataset.py
@@ -23,8 +23,8 @@ def test_dataset_wrong_catalog_info(base_catalog_info_data):
 def test_read_from_hipscat(dataset_path, base_catalog_info_file, assert_catalog_info_matches_dict):
     dataset = Dataset.read_from_hipscat(dataset_path)
     assert dataset.on_disk
-    assert dataset.catalog_path == str(dataset_path)
-    assert dataset.catalog_base_dir == str(dataset_path)
+    assert str(dataset.catalog_path) == str(dataset_path)
+    assert str(dataset.catalog_base_dir) == str(dataset_path)
     with open(base_catalog_info_file, "r", encoding="utf-8") as cat_info_file:
         catalog_info_json = json.load(cat_info_file)
         assert_catalog_info_matches_dict(dataset.catalog_info, catalog_info_json)

--- a/tests/hipscat/catalog/index/test_index_catalog.py
+++ b/tests/hipscat/catalog/index/test_index_catalog.py
@@ -10,7 +10,7 @@ def test_loc_partition(small_sky_source_object_index_dir):
 
     assert isinstance(catalog, IndexCatalog)
     assert catalog.on_disk
-    assert catalog.catalog_path == str(small_sky_source_object_index_dir)
+    assert catalog.catalog_path == small_sky_source_object_index_dir
 
     npt.assert_array_equal(catalog.loc_partitions([700]), [HealpixPixel(2, 184)])
     npt.assert_array_equal(catalog.loc_partitions([707]), [HealpixPixel(2, 176), HealpixPixel(2, 178)])

--- a/tests/hipscat/catalog/index/test_index_catalog_info.py
+++ b/tests/hipscat/catalog/index/test_index_catalog_info.py
@@ -5,7 +5,6 @@ import pytest
 
 from hipscat.catalog.catalog_type import CatalogType
 from hipscat.catalog.index.index_catalog_info import IndexCatalogInfo
-from hipscat.io import file_io
 
 
 def test_index_catalog_info(

--- a/tests/hipscat/catalog/index/test_index_catalog_info.py
+++ b/tests/hipscat/catalog/index/test_index_catalog_info.py
@@ -28,8 +28,7 @@ def test_str(index_catalog_info_with_extra):
 
 
 def test_read_from_file(index_catalog_info_file, assert_catalog_info_matches_dict):
-    cat_info_fp = file_io.get_file_pointer_from_path(index_catalog_info_file)
-    catalog_info = IndexCatalogInfo.read_from_metadata_file(cat_info_fp)
+    catalog_info = IndexCatalogInfo.read_from_metadata_file(index_catalog_info_file)
     for column in [
         "catalog_name",
         "catalog_type",

--- a/tests/hipscat/catalog/margin_cache/test_margin_cache_catalog_info.py
+++ b/tests/hipscat/catalog/margin_cache/test_margin_cache_catalog_info.py
@@ -22,8 +22,7 @@ def test_str(margin_cache_catalog_info_data):
 
 
 def test_read_from_file(margin_cache_catalog_info_file, assert_catalog_info_matches_dict):
-    cat_info_fp = file_io.get_file_pointer_from_path(margin_cache_catalog_info_file)
-    catalog_info = MarginCacheCatalogInfo.read_from_metadata_file(cat_info_fp)
+    catalog_info = MarginCacheCatalogInfo.read_from_metadata_file(margin_cache_catalog_info_file)
     for column in [
         "catalog_name",
         "catalog_type",

--- a/tests/hipscat/catalog/margin_cache/test_margin_cache_catalog_info.py
+++ b/tests/hipscat/catalog/margin_cache/test_margin_cache_catalog_info.py
@@ -5,7 +5,6 @@ import pytest
 
 from hipscat.catalog.catalog_type import CatalogType
 from hipscat.catalog.margin_cache.margin_cache_catalog_info import MarginCacheCatalogInfo
-from hipscat.io import file_io
 
 
 def test_margin_cache_catalog_info(margin_cache_catalog_info_data, assert_catalog_info_matches_dict):

--- a/tests/hipscat/catalog/margin_cache/test_margin_catalog.py
+++ b/tests/hipscat/catalog/margin_cache/test_margin_catalog.py
@@ -38,7 +38,7 @@ def test_read_from_file(margin_catalog_path, margin_catalog_pixels, margin_catal
 
     assert isinstance(catalog, MarginCatalog)
     assert catalog.on_disk
-    assert catalog.catalog_path == str(margin_catalog_path)
+    assert catalog.catalog_path == margin_catalog_path
     assert len(catalog.get_healpix_pixels()) == len(margin_catalog_pixels)
     assert catalog.get_healpix_pixels() == margin_catalog_pixels
 

--- a/tests/hipscat/catalog/source_catalog/test_source_catalog_info.py
+++ b/tests/hipscat/catalog/source_catalog/test_source_catalog_info.py
@@ -5,7 +5,6 @@ import pytest
 
 from hipscat.catalog.catalog_type import CatalogType
 from hipscat.catalog.source_catalog.source_catalog_info import SourceCatalogInfo
-from hipscat.io import file_io
 
 
 def test_source_catalog_info(

--- a/tests/hipscat/catalog/source_catalog/test_source_catalog_info.py
+++ b/tests/hipscat/catalog/source_catalog/test_source_catalog_info.py
@@ -30,8 +30,7 @@ def test_str(source_catalog_info_with_extra):
 
 
 def test_read_from_file(source_catalog_info_file, assert_catalog_info_matches_dict):
-    cat_info_fp = file_io.get_file_pointer_from_path(source_catalog_info_file)
-    catalog_info = SourceCatalogInfo.read_from_metadata_file(cat_info_fp)
+    catalog_info = SourceCatalogInfo.read_from_metadata_file(source_catalog_info_file)
     for column in [
         "catalog_name",
         "catalog_type",

--- a/tests/hipscat/catalog/test_catalog_info.py
+++ b/tests/hipscat/catalog/test_catalog_info.py
@@ -2,7 +2,6 @@ import dataclasses
 import json
 
 from hipscat.catalog.catalog_info import CatalogInfo
-from hipscat.io import file_io
 
 
 def test_catalog_info(catalog_info_data, assert_catalog_info_matches_dict):

--- a/tests/hipscat/catalog/test_catalog_info.py
+++ b/tests/hipscat/catalog/test_catalog_info.py
@@ -28,8 +28,7 @@ def test_str(catalog_info_data):
 
 
 def test_read_from_file(catalog_info_file, assert_catalog_info_matches_dict):
-    cat_info_fp = file_io.get_file_pointer_from_path(catalog_info_file)
-    catalog_info = CatalogInfo.read_from_metadata_file(cat_info_fp)
+    catalog_info = CatalogInfo.read_from_metadata_file(catalog_info_file)
     for column in [
         "catalog_name",
         "catalog_type",

--- a/tests/hipscat/catalog/test_partition_info.py
+++ b/tests/hipscat/catalog/test_partition_info.py
@@ -87,14 +87,12 @@ def test_load_partition_info_small_sky_order1(small_sky_order1_dir):
 
 def test_load_partition_no_file(tmp_path):
     wrong_path = tmp_path / "_metadata"
-    wrong_pointer = file_io.get_file_pointer_from_path(wrong_path)
     with pytest.raises(FileNotFoundError):
-        PartitionInfo.read_from_file(wrong_pointer)
+        PartitionInfo.read_from_file(wrong_path)
 
-    wrong_path = tmp_path, "partition_info.csv"
-    wrong_pointer = file_io.get_file_pointer_from_path(wrong_path)
+    wrong_path = tmp_path / "partition_info.csv"
     with pytest.raises(FileNotFoundError):
-        PartitionInfo.read_from_csv(wrong_pointer)
+        PartitionInfo.read_from_csv(wrong_path)
 
 
 def test_get_highest_order(small_sky_order1_dir):

--- a/tests/hipscat/catalog/test_partition_info.py
+++ b/tests/hipscat/catalog/test_partition_info.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 
 from hipscat.catalog import PartitionInfo
-from hipscat.io import file_io, paths
+from hipscat.io import paths
 from hipscat.pixel_math import HealpixPixel
 
 

--- a/tests/hipscat/io/conftest.py
+++ b/tests/hipscat/io/conftest.py
@@ -15,7 +15,7 @@ from hipscat.io.file_io.file_pointer import does_file_or_directory_exist
 
 @pytest.fixture
 def assert_text_file_matches():
-    def assert_text_file_matches(expected_lines, file_name, storage_options: dict = None):
+    def assert_text_file_matches(expected_lines, file_name):
         """Convenience method to read a text file and compare the contents, line for line.
 
         When file contents get even a little bit big, it can be difficult to see
@@ -30,12 +30,9 @@ def assert_text_file_matches():
         Args:
             expected_lines(:obj:`string array`) list of strings, formatted as regular expressions.
             file_name (str): fully-specified path of the file to read
-            storage_options (dict): dictionary of filesystem storage options
         """
-        assert does_file_or_directory_exist(
-            file_name, storage_options=storage_options
-        ), f"file not found [{file_name}]"
-        contents = load_text_file(file_name, storage_options=storage_options)
+        assert does_file_or_directory_exist(file_name), f"file not found [{file_name}]"
+        contents = load_text_file(file_name)
 
         assert len(expected_lines) == len(
             contents

--- a/tests/hipscat/io/file_io/test_file_io.py
+++ b/tests/hipscat/io/file_io/test_file_io.py
@@ -50,6 +50,8 @@ def test_make_and_remove_directory(tmp_path):
     test_dir_path = tmp_path / "test_path"
     assert not does_file_or_directory_exist(test_dir_path)
     make_directory(test_dir_path)
+    make_directory(test_dir_path / "subdirectory")
+    (test_dir_path / "subdirectory" / "file").touch()
     assert does_file_or_directory_exist(test_dir_path)
     remove_directory(test_dir_path)
     assert not does_file_or_directory_exist(test_dir_path)

--- a/tests/hipscat/io/file_io/test_file_io.py
+++ b/tests/hipscat/io/file_io/test_file_io.py
@@ -16,40 +16,14 @@ from hipscat.io.file_io import (
     write_dataframe_to_csv,
     write_string_to_file,
 )
-from hipscat.io.file_io.file_io import unnest_headers_for_pandas
 from hipscat.io.file_io.file_pointer import does_file_or_directory_exist
-from hipscat.io.paths import pixel_catalog_file
-from hipscat.pixel_math.healpix_pixel import HealpixPixel
+
 
 def test_make_directory(tmp_path):
     test_dir_path = tmp_path / "test_path"
     assert not does_file_or_directory_exist(test_dir_path)
     make_directory(test_dir_path)
     assert does_file_or_directory_exist(test_dir_path)
-
-
-def test_unnest_headers_for_pandas():
-    storage_options = {
-        "headers": {"Authorization": "Bearer my_token"},
-    }
-    storage_options_str = {"Authorization": "Bearer my_token"}
-    assert storage_options_str == unnest_headers_for_pandas(storage_options)
-
-    storage_options = {
-        "key1": "value1",
-        "headers": {"Authorization": "Bearer my_token", "Content": "X"},
-    }
-    storage_options_str = {"key1": "value1", "Authorization": "Bearer my_token", "Content": "X"}
-    assert storage_options_str == unnest_headers_for_pandas(storage_options)
-
-    storage_options = {
-        "key1": "value1",
-        "key2": None,
-    }
-    storage_options_str = {"key1": "value1", "key2": None}
-    assert storage_options_str == unnest_headers_for_pandas(storage_options)
-
-    assert None is unnest_headers_for_pandas(None)
 
 
 def test_make_existing_directory_raises(tmp_path):

--- a/tests/hipscat/io/file_io/test_file_io.py
+++ b/tests/hipscat/io/file_io/test_file_io.py
@@ -6,11 +6,9 @@ import pytest
 
 from hipscat.io.file_io import (
     delete_file,
-    get_file_pointer_from_path,
     load_csv_to_pandas,
     load_csv_to_pandas_generator,
     load_json_file,
-    load_parquet_to_pandas,
     make_directory,
     read_parquet_dataset,
     read_parquet_file_to_pandas,
@@ -21,13 +19,12 @@ from hipscat.io.file_io import (
 from hipscat.io.file_io.file_io import unnest_headers_for_pandas
 from hipscat.io.file_io.file_pointer import does_file_or_directory_exist
 from hipscat.io.paths import pixel_catalog_file
-
+from hipscat.pixel_math.healpix_pixel import HealpixPixel
 
 def test_make_directory(tmp_path):
     test_dir_path = tmp_path / "test_path"
     assert not does_file_or_directory_exist(test_dir_path)
-    test_dir_pointer = get_file_pointer_from_path(test_dir_path)
-    make_directory(test_dir_pointer)
+    make_directory(test_dir_path)
     assert does_file_or_directory_exist(test_dir_path)
 
 
@@ -59,9 +56,8 @@ def test_make_existing_directory_raises(tmp_path):
     test_dir_path = tmp_path / "test_path"
     make_directory(test_dir_path)
     assert does_file_or_directory_exist(test_dir_path)
-    test_dir_pointer = get_file_pointer_from_path(test_dir_path)
     with pytest.raises(OSError):
-        make_directory(test_dir_pointer)
+        make_directory(test_dir_path)
 
 
 def test_make_existing_directory_existok(tmp_path):
@@ -71,8 +67,7 @@ def test_make_existing_directory_existok(tmp_path):
     make_directory(test_inner_dir_path)
     assert does_file_or_directory_exist(test_dir_path)
     assert does_file_or_directory_exist(test_inner_dir_path)
-    test_dir_pointer = get_file_pointer_from_path(test_dir_path)
-    make_directory(test_dir_pointer, exist_ok=True)
+    make_directory(test_dir_path, exist_ok=True)
     assert does_file_or_directory_exist(test_dir_path)
     assert does_file_or_directory_exist(test_inner_dir_path)
 
@@ -80,31 +75,29 @@ def test_make_existing_directory_existok(tmp_path):
 def test_make_and_remove_directory(tmp_path):
     test_dir_path = tmp_path / "test_path"
     assert not does_file_or_directory_exist(test_dir_path)
-    test_dir_pointer = get_file_pointer_from_path(test_dir_path)
-    make_directory(test_dir_pointer)
+    make_directory(test_dir_path)
     assert does_file_or_directory_exist(test_dir_path)
-    remove_directory(test_dir_pointer)
+    remove_directory(test_dir_path)
     assert not does_file_or_directory_exist(test_dir_path)
 
     ## Directory no longer exists to be deleted.
     with pytest.raises(FileNotFoundError):
-        remove_directory(test_dir_pointer)
+        remove_directory(test_dir_path)
 
     ## Directory doesn't exist, but shouldn't throw an error.
-    remove_directory(test_dir_pointer, ignore_errors=True)
+    remove_directory(test_dir_path, ignore_errors=True)
     assert not does_file_or_directory_exist(test_dir_path)
 
 
 def test_write_string_to_file(tmp_path):
     test_file_path = tmp_path / "text_file.txt"
-    test_file_pointer = get_file_pointer_from_path(test_file_path)
     test_string = "this is a test"
-    write_string_to_file(test_file_pointer, test_string, encoding="utf-8")
+    write_string_to_file(test_file_path, test_string, encoding="utf-8")
     with open(test_file_path, "r", encoding="utf-8") as file:
         data = file.read()
         assert data == test_string
-    delete_file(test_file_pointer)
-    assert not does_file_or_directory_exist(test_file_pointer)
+    delete_file(test_file_path)
+    assert not does_file_or_directory_exist(test_file_path)
 
 
 def test_load_json(small_sky_dir):
@@ -112,8 +105,7 @@ def test_load_json(small_sky_dir):
     json_dict = None
     with open(catalog_info_path, "r", encoding="utf-8") as json_file:
         json_dict = json.load(json_file)
-    catalog_info_pointer = get_file_pointer_from_path(catalog_info_path)
-    loaded_json_dict = load_json_file(catalog_info_pointer, encoding="utf-8")
+    loaded_json_dict = load_json_file(catalog_info_path, encoding="utf-8")
     assert loaded_json_dict == json_dict
 
 
@@ -132,18 +124,10 @@ def test_load_csv_to_pandas_generator(small_sky_source_dir):
     assert num_reads == 2
 
 
-def test_load_parquet_to_pandas(small_sky_dir):
-    pixel_data_path = pixel_catalog_file(small_sky_dir, 0, 11)
-    parquet_df = pd.read_parquet(pixel_data_path)
-    loaded_df = load_parquet_to_pandas(pixel_data_path)
-    pd.testing.assert_frame_equal(parquet_df, loaded_df)
-
-
 def test_write_df_to_csv(tmp_path):
     random_df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)), columns=list("ABCD"))
     test_file_path = tmp_path / "test.csv"
-    test_file_pointer = get_file_pointer_from_path(test_file_path)
-    write_dataframe_to_csv(random_df, test_file_pointer, index=False)
+    write_dataframe_to_csv(random_df, test_file_path, index=False)
     loaded_df = pd.read_csv(test_file_path)
     pd.testing.assert_frame_equal(loaded_df, random_df)
 
@@ -152,8 +136,7 @@ def test_read_parquet_data(tmp_path):
     random_df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)), columns=list("ABCD"))
     test_file_path = tmp_path / "test.parquet"
     random_df.to_parquet(test_file_path)
-    file_pointer = get_file_pointer_from_path(test_file_path)
-    dataframe = read_parquet_file_to_pandas(file_pointer)
+    dataframe = read_parquet_file_to_pandas(test_file_path)
     pd.testing.assert_frame_equal(dataframe, random_df)
 
 

--- a/tests/hipscat/io/file_io/test_file_pointers.py
+++ b/tests/hipscat/io/file_io/test_file_pointers.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 
-import pytest
-
-from hipscat.io.file_io import (  # strip_leading_slash_for_pyarrow,
+from hipscat.io.file_io import (
     append_paths_to_pointer,
     directory_has_contents,
     does_file_or_directory_exist,
@@ -10,8 +8,6 @@ from hipscat.io.file_io import (  # strip_leading_slash_for_pyarrow,
     get_directory_contents,
     is_regular_file,
 )
-
-# from hipscat.io.file_io.file_pointer import get_fs
 
 
 def test_file_or_dir_exist(small_sky_dir):

--- a/tests/hipscat/io/file_io/test_file_pointers.py
+++ b/tests/hipscat/io/file_io/test_file_pointers.py
@@ -2,50 +2,33 @@ from pathlib import Path
 
 import pytest
 
-from hipscat.io.file_io import (
+from hipscat.io.file_io import (  # strip_leading_slash_for_pyarrow,
     append_paths_to_pointer,
     directory_has_contents,
     does_file_or_directory_exist,
     find_files_matching_path,
-    get_basename_from_filepointer,
     get_directory_contents,
-    get_file_pointer_for_fs,
-    get_file_pointer_from_path,
     is_regular_file,
-    strip_leading_slash_for_pyarrow,
 )
-from hipscat.io.file_io.file_pointer import get_fs
 
-
-def test_get_pointer_from_path(tmp_path):
-    tmp_pointer = get_file_pointer_from_path(str(tmp_path))
-    assert str(tmp_pointer) == str(tmp_path)
-
-
-def test_get_basename_from_filepointer(tmp_path):
-    catalog_info_string = tmp_path / "catalog_info.json"
-    catalog_info_pointer = get_file_pointer_from_path(catalog_info_string)
-    assert get_basename_from_filepointer(catalog_info_pointer) == "catalog_info.json"
+# from hipscat.io.file_io.file_pointer import get_fs
 
 
 def test_file_or_dir_exist(small_sky_dir):
-    small_sky_pointer = get_file_pointer_from_path(small_sky_dir)
-    assert does_file_or_directory_exist(small_sky_pointer)
+    assert does_file_or_directory_exist(small_sky_dir)
+
     catalog_info_string = small_sky_dir / "catalog_info.json"
-    catalog_info_pointer = get_file_pointer_from_path(catalog_info_string)
-    assert does_file_or_directory_exist(catalog_info_pointer)
+    assert does_file_or_directory_exist(catalog_info_string)
 
 
 def test_file_or_dir_exist_false(small_sky_dir):
-    small_sky_pointer = get_file_pointer_from_path(str(small_sky_dir) + "incorrect file")
-    assert not does_file_or_directory_exist(small_sky_pointer)
+    assert not does_file_or_directory_exist(str(small_sky_dir) + "incorrect file")
 
 
 def test_append_paths_to_pointer(tmp_path):
     test_paths = ["folder", "file.txt"]
     test_path = tmp_path / "folder" / "file.txt"
-    tmp_pointer = get_file_pointer_from_path(str(tmp_path))
-    assert append_paths_to_pointer(tmp_pointer, *test_paths) == str(test_path)
+    assert str(append_paths_to_pointer(tmp_path, *test_paths)) == str(test_path)
 
 
 def test_is_regular_file(small_sky_dir):
@@ -62,12 +45,6 @@ def test_find_files_matching_path(small_sky_dir):
     ## no_wildcard
     matching_files = find_files_matching_path(small_sky_dir, "catalog_info.json")
     assert len(matching_files) == 1
-
-    matching_files_with_protocol = find_files_matching_path(
-        small_sky_dir, "catalog_info.json", include_protocol=True
-    )
-    assert matching_files_with_protocol[0] != matching_files[0]
-    assert matching_files[0] in matching_files_with_protocol[0]
 
     ## wilcard in the name (matches catalog_info and provenance_info)
     assert len(find_files_matching_path(small_sky_dir, "*.json")) == 2
@@ -106,42 +83,3 @@ def test_get_directory_contents(small_sky_order1_dir, tmp_path):
     assert small_sky_paths == expected
 
     assert len(get_directory_contents(tmp_path)) == 0
-
-
-def test_get_fs():
-    filesystem, _ = get_fs("file://")
-    assert "file" in filesystem.protocol
-
-    # this will fail if the environment installs lakefs to import
-    with pytest.raises(ImportError):
-        get_fs("lakefs://")
-
-    with pytest.raises(ValueError):
-        get_fs("invalid://")
-
-
-def test_get_file_pointer_for_fs():
-    test_abfs_protocol_path = get_file_pointer_from_path("abfs:///container/path/to/parquet/file")
-    assert (
-        get_file_pointer_for_fs("abfs", file_pointer=test_abfs_protocol_path)
-        == "/container/path/to/parquet/file"
-    )
-    test_s3_protocol_path = get_file_pointer_from_path("s3:///bucket/path/to/catalog.json")
-    assert get_file_pointer_for_fs("s3", file_pointer=test_s3_protocol_path) == "/bucket/path/to/catalog.json"
-    test_local_path = get_file_pointer_from_path("/path/to/file")
-    assert get_file_pointer_for_fs("file", file_pointer=test_local_path) == test_local_path
-    test_local_protocol_path = get_file_pointer_from_path("file:///path/to/file")
-    assert get_file_pointer_for_fs("file", file_pointer=test_local_protocol_path) == "/path/to/file"
-
-
-def test_strip_leading_slash_for_pyarrow():
-    test_leading_slash_filename = get_file_pointer_from_path("/bucket/path/test.txt")
-    assert (
-        strip_leading_slash_for_pyarrow(test_leading_slash_filename, protocol="abfs")
-        == "bucket/path/test.txt"
-    )
-    test_non_leading_slash_filename = get_file_pointer_from_path("bucket/path/test.txt")
-    assert (
-        strip_leading_slash_for_pyarrow(test_non_leading_slash_filename, protocol="abfs")
-        == "bucket/path/test.txt"
-    )

--- a/tests/hipscat/io/test_paths.py
+++ b/tests/hipscat/io/test_paths.py
@@ -10,17 +10,17 @@ def test_pixel_directory():
     """Simple case with sensical inputs"""
     expected = "/foo/Norder=0/Dir=0"
     result = paths.pixel_directory("/foo", 0, 5)
-    assert result == expected
+    assert str(result) == expected
 
 
 def test_pixel_directory_number():
     """Simple case with sensical inputs"""
     expected = "/foo/Norder=0/Dir=0"
     result = paths.pixel_directory("/foo", pixel_order=0, pixel_number=5, directory_number=0)
-    assert result == expected
+    assert str(result) == expected
 
     result = paths.pixel_directory("/foo", pixel_order=0, directory_number=0)
-    assert result == expected
+    assert str(result) == expected
 
 
 def test_pixel_directory_missing():
@@ -38,19 +38,25 @@ def test_pixel_directory_nonint():
 def test_pixel_catalog_file():
     """Simple case with sensical inputs"""
     expected = "/foo/Norder=0/Dir=0/Npix=5.parquet"
-    result = paths.pixel_catalog_file("/foo", 0, 5)
-    assert result == expected
+    result = paths.pixel_catalog_file("/foo", HealpixPixel(0, 5))
+    assert str(result) == expected
 
+
+def test_pixel_catalog_file_w_query_params():
+    expected = "https://foo/Norder=0/Dir=0/Npix=5.parquet?columns=ID%2CRA%2CDEC%2Cr_auto&filters=r_auto%3C13"
+    query_params = {"columns": ["ID", "RA", "DEC", "r_auto"], "filters": ["r_auto<13"]}
+    result = paths.pixel_catalog_file("https://foo", HealpixPixel(0, 5), query_params=query_params)
+    assert expected == str(result)
 
 def test_pixel_catalog_file_nonint():
     """Simple case with non-integer inputs"""
-    with pytest.raises(ValueError):
+    with pytest.raises(AttributeError):
         paths.pixel_catalog_file("/foo", "zero", "five")
 
 
 def test_pixel_catalog_files():
     expected = ["/foo/Norder=0/Dir=0/Npix=5.parquet", "/foo/Norder=1/Dir=0/Npix=16.parquet"]
-    result = paths.pixel_catalog_files("/foo", [HealpixPixel(0, 5), HealpixPixel(1, 16)])
+    result = paths.pixel_catalog_files("/foo/", [HealpixPixel(0, 5), HealpixPixel(1, 16)])
     assert expected == result
 
 

--- a/tests/hipscat/io/test_paths.py
+++ b/tests/hipscat/io/test_paths.py
@@ -48,6 +48,7 @@ def test_pixel_catalog_file_w_query_params():
     result = paths.pixel_catalog_file("https://foo", HealpixPixel(0, 5), query_params=query_params)
     assert expected == str(result)
 
+
 def test_pixel_catalog_file_nonint():
     """Simple case with non-integer inputs"""
     with pytest.raises(AttributeError):

--- a/tests/hipscat/io/test_validation.py
+++ b/tests/hipscat/io/test_validation.py
@@ -7,40 +7,38 @@ from pathlib import Path
 import pytest
 
 from hipscat.catalog import PartitionInfo
-from hipscat.io import get_file_pointer_from_path, paths, write_catalog_info
+from hipscat.io import paths, write_catalog_info
 from hipscat.io.validation import is_valid_catalog
 
 
 def test_is_valid_catalog(tmp_path, small_sky_catalog, small_sky_pixels):
     """Tests if the catalog_info and partition_info files are valid"""
     # An empty directory means an invalid catalog
-    catalog_dir_pointer = get_file_pointer_from_path(tmp_path)
-    assert not is_valid_catalog(catalog_dir_pointer)
+    assert not is_valid_catalog(tmp_path)
 
     # Having the catalog_info file is not enough
-    write_catalog_info(catalog_dir_pointer, small_sky_catalog.catalog_info)
-    assert not is_valid_catalog(catalog_dir_pointer)
+    write_catalog_info(tmp_path, small_sky_catalog.catalog_info)
+    assert not is_valid_catalog(tmp_path)
 
     # The catalog is valid if both the catalog_info and _metadata files exist,
     # and the catalog_info is in a valid format
-    total_rows = PartitionInfo.from_healpix(small_sky_pixels).write_to_metadata_files(catalog_dir_pointer)
+    total_rows = PartitionInfo.from_healpix(small_sky_pixels).write_to_metadata_files(tmp_path)
     assert total_rows == 1
-    assert is_valid_catalog(catalog_dir_pointer)
+    assert is_valid_catalog(tmp_path)
 
     # A partition_info file alone is also not enough
-    catalog_info_pointer = paths.get_catalog_info_pointer(catalog_dir_pointer)
+    catalog_info_pointer = paths.get_catalog_info_pointer(tmp_path)
     os.remove(catalog_info_pointer)
-    assert not is_valid_catalog(catalog_dir_pointer)
+    assert not is_valid_catalog(tmp_path)
 
     # The catalog_info file needs to be in the correct format
     small_sky_catalog.catalog_info.catalog_type = "invalid"
-    write_catalog_info(catalog_dir_pointer, small_sky_catalog.catalog_info)
-    assert not is_valid_catalog(catalog_dir_pointer)
+    write_catalog_info(tmp_path, small_sky_catalog.catalog_info)
+    assert not is_valid_catalog(tmp_path)
 
 
 def test_is_valid_catalog_strict(tmp_path, small_sky_catalog, small_sky_pixels, small_sky_order1_pixels):
     """Tests if the catalog_info and partition_info files are valid"""
-    catalog_dir_pointer = get_file_pointer_from_path(tmp_path)
     # Set up our arguments once, just to be sure we're calling validation
     # the same way throughout this test scene.
     flags = {
@@ -50,23 +48,23 @@ def test_is_valid_catalog_strict(tmp_path, small_sky_catalog, small_sky_pixels, 
     }
     # An empty directory means an invalid catalog
     with pytest.warns():
-        assert not is_valid_catalog(catalog_dir_pointer, **flags)
+        assert not is_valid_catalog(tmp_path, **flags)
 
     # Having the catalog_info file is not enough
-    write_catalog_info(catalog_dir_pointer, small_sky_catalog.catalog_info)
+    write_catalog_info(tmp_path, small_sky_catalog.catalog_info)
     with pytest.warns():
-        assert not is_valid_catalog(catalog_dir_pointer, **flags)
+        assert not is_valid_catalog(tmp_path, **flags)
 
     # Adds the _metadata and _common_metadata, but that's not enough.
-    total_rows = PartitionInfo.from_healpix(small_sky_pixels).write_to_metadata_files(catalog_dir_pointer)
+    total_rows = PartitionInfo.from_healpix(small_sky_pixels).write_to_metadata_files(tmp_path)
     assert total_rows == 1
     with pytest.warns():
-        assert not is_valid_catalog(catalog_dir_pointer, **flags)
+        assert not is_valid_catalog(tmp_path, **flags)
 
     # Adds the partition_info.csv, but that's STILL not enough
-    PartitionInfo.from_healpix(small_sky_pixels).write_to_file(catalog_path=catalog_dir_pointer)
+    PartitionInfo.from_healpix(small_sky_pixels).write_to_file(catalog_path=tmp_path)
     with pytest.warns():
-        assert not is_valid_catalog(catalog_dir_pointer, **flags)
+        assert not is_valid_catalog(tmp_path, **flags)
 
     # This outta do it! Add parquet files that match the _metadata pixels.
     shutil.copytree(
@@ -74,12 +72,12 @@ def test_is_valid_catalog_strict(tmp_path, small_sky_catalog, small_sky_pixels, 
         tmp_path / "Norder=0",
     )
 
-    assert is_valid_catalog(catalog_dir_pointer, **flags)
+    assert is_valid_catalog(tmp_path, **flags)
 
     # Uh oh! Now the sets of pixels don't match between _metadata and partition_info.csv!
-    PartitionInfo.from_healpix(small_sky_order1_pixels).write_to_file(catalog_path=catalog_dir_pointer)
+    PartitionInfo.from_healpix(small_sky_order1_pixels).write_to_file(catalog_path=tmp_path)
     with pytest.warns():
-        assert not is_valid_catalog(catalog_dir_pointer, **flags)
+        assert not is_valid_catalog(tmp_path, **flags)
 
 
 def test_is_valid_catalog_fail_fast(tmp_path, small_sky_catalog, small_sky_pixels):
@@ -92,34 +90,32 @@ def test_is_valid_catalog_fail_fast(tmp_path, small_sky_catalog, small_sky_pixel
         "verbose": False,  # don't bother printing anything.
     }
     # An empty directory means an invalid catalog
-    catalog_dir_pointer = get_file_pointer_from_path(tmp_path)
     with pytest.raises(ValueError, match="catalog_info.json"):
-        is_valid_catalog(catalog_dir_pointer, **flags)
+        is_valid_catalog(tmp_path, **flags)
 
     # Having the catalog_info file is not enough
-    write_catalog_info(catalog_dir_pointer, small_sky_catalog.catalog_info)
+    write_catalog_info(tmp_path, small_sky_catalog.catalog_info)
     with pytest.raises(ValueError, match="partition_info.csv"):
-        is_valid_catalog(catalog_dir_pointer, **flags)
+        is_valid_catalog(tmp_path, **flags)
 
-    PartitionInfo.from_healpix(small_sky_pixels).write_to_file(catalog_path=catalog_dir_pointer)
+    PartitionInfo.from_healpix(small_sky_pixels).write_to_file(catalog_path=tmp_path)
     with pytest.raises(ValueError, match="_metadata"):
-        is_valid_catalog(catalog_dir_pointer, **flags)
+        is_valid_catalog(tmp_path, **flags)
 
-    total_rows = PartitionInfo.from_healpix(small_sky_pixels).write_to_metadata_files(catalog_dir_pointer)
+    total_rows = PartitionInfo.from_healpix(small_sky_pixels).write_to_metadata_files(tmp_path)
     assert total_rows == 1
     with pytest.raises(ValueError, match="parquet paths"):
-        is_valid_catalog(catalog_dir_pointer, **flags)
+        is_valid_catalog(tmp_path, **flags)
 
     shutil.copytree(
         Path(small_sky_catalog.catalog_path) / "Norder=0",
         tmp_path / "Norder=0",
     )
-    assert is_valid_catalog(catalog_dir_pointer, **flags)
+    assert is_valid_catalog(tmp_path, **flags)
 
 
 def test_is_valid_catalog_verbose_fail(tmp_path, capsys):
     """Tests if the catalog_info and partition_info files are valid"""
-    catalog_dir_pointer = get_file_pointer_from_path(tmp_path)
     # Set up our arguments once, just to be sure we're calling validation
     # the same way throughout this test scene.
     flags = {
@@ -128,7 +124,7 @@ def test_is_valid_catalog_verbose_fail(tmp_path, capsys):
         "verbose": True,  # print messages along the way
     }
     # An empty directory means an invalid catalog
-    assert not is_valid_catalog(catalog_dir_pointer, **flags)
+    assert not is_valid_catalog(tmp_path, **flags)
 
     captured = capsys.readouterr().out
     assert "Validating catalog at path" in captured

--- a/tests/hipscat/io/test_write_metadata.py
+++ b/tests/hipscat/io/test_write_metadata.py
@@ -1,7 +1,5 @@
 """Tests of file IO (reads and writes)"""
 
-from pathlib import Path
-
 import numpy as np
 import numpy.testing as npt
 import pytest

--- a/tests/hipscat/io/test_write_metadata.py
+++ b/tests/hipscat/io/test_write_metadata.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import numpy as np
 import numpy.testing as npt
 import pytest
+from upath import UPath
 
 import hipscat.io.write_metadata as io
 import hipscat.pixel_math as hist
@@ -56,11 +57,10 @@ def test_write_json_file(assert_text_file_matches, tmp_path):
 
 
 def test_write_json_paths(assert_text_file_matches, tmp_path):
-    pathlib_path = Path(tmp_path)
-    file_pointer = file_io.FilePointer(tmp_path)
+    pathlib_path = UPath(tmp_path)
     dictionary = {}
     dictionary["pathlib_path"] = pathlib_path
-    dictionary["file_pointer"] = file_pointer
+    dictionary["file_pointer"] = tmp_path
     dictionary["first_greek"] = "alpha"
     expected_lines = [
         "{\n",


### PR DESCRIPTION
## Change Description

Related to #320, #313, #307
Closes #79 

## Solution Description

Use fsspec's project, [universal-pathlib](https://github.com/fsspec/universal_pathlib) as a path provider. In this way, everywhere we currently pass in a `FilePointer` we can use a `Path` instead, and when we need to create remote connections, use `UPath`.

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation