### PR TITLE
Limit kwargs passed to file.open.

### DIFF
--- a/src/hipscat/io/file_io/file_io.py
+++ b/src/hipscat/io/file_io/file_io.py
@@ -293,7 +293,7 @@ def delete_file(file_handle: UPath):
     file_handle.unlink()
 
 
-def read_parquet_file_to_pandas(file_pointer: UPath, **kwargs) -> pd.DataFrame:
+def read_parquet_file_to_pandas(file_pointer: UPath, file_open_kwargs: dict = None, **kwargs) -> pd.DataFrame:
     """Reads a parquet file to a pandas DataFrame
 
     Args:
@@ -304,5 +304,7 @@ def read_parquet_file_to_pandas(file_pointer: UPath, **kwargs) -> pd.DataFrame:
         Pandas DataFrame with the data from the parquet file
     """
     file_pointer = get_upath(file_pointer)
-    with file_pointer.open("rb", **kwargs) as parquet_file:
+    if file_open_kwargs is None:
+        file_open_kwargs = {}
+    with file_pointer.open("rb", **file_open_kwargs) as parquet_file:
         return pd.read_parquet(parquet_file, **kwargs)


### PR DESCRIPTION
## Change Description

Not all file open calls can handle so many pass-through kwargs, and there may be overlap with other kwargs passed to the pandas call. This attempts to split into different use cases.

Fixes CI failures in https://github.com/astronomy-commons/lsdb/pull/413