### PR TITLE
Remove unused methods in pixel margin module

### DIFF
--- a/docs/guide/pixel_math.md
+++ b/docs/guide/pixel_math.md
@@ -154,9 +154,6 @@ faces).
 #### Implementation
 Pretty straightforward implementation of the algorithm above.
 
-### pixel_is_polar
-Because of the nature of spherical coordinate systems, hipscat runs into some tricky edge cases at the poles. To ensure we can appropriately handle those problems, we need to check if a pixel is one of the four 'polar pixels'.
-
 #### Algorithm
 In the ring id scheme for `healpix`, the first and last 4 pixels are the polar pixels. To determine whether a nest scheme pixel is at the poles, all we have to do is convert the pixel into the ring scheme and determine if it falls at the beginning or end of the range 0 -> npix. So, if in the ring scheme the pix is `<= 3`, or `>= npix - 4`, we can safely assume that it is a polar pixel.
 

--- a/src/hipscat/pixel_math/__init__.py
+++ b/src/hipscat/pixel_math/__init__.py
@@ -5,4 +5,4 @@ from .healpix_pixel_convertor import HealpixInputTypes, get_healpix_pixel
 from .hipscat_id import compute_hipscat_id, hipscat_id_to_healpix
 from .margin_bounding import check_margin_bounds
 from .partition_stats import empty_histogram, generate_alignment, generate_histogram
-from .pixel_margins import get_edge, get_margin, pixel_is_polar
+from .pixel_margins import get_margin

--- a/src/hipscat/pixel_math/healpix_shim.py
+++ b/src/hipscat/pixel_math/healpix_shim.py
@@ -46,10 +46,6 @@ def ring2nest(*args, **kwargs):
     return hp.ring2nest(*args, **kwargs)
 
 
-def nest2ring(*args, **kwargs):
-    return hp.nest2ring(*args, **kwargs)
-
-
 def unseen_pixel():
     return hp.pixelfunc.UNSEEN
 

--- a/src/hipscat/pixel_math/pixel_margins.py
+++ b/src/hipscat/pixel_math/pixel_margins.py
@@ -90,7 +90,7 @@ def get_margin(order, pix, d_order):
     _, _, pix_face = hp.pix2xyf(nside, pix, nest=True)
     _, _, faces = hp.pix2xyf(nside, neighbors, nest=True)
 
-    # indices which tell get_edge() which edge/verted to return
+    # indices which tell get_edge() which edge/vertex to return
     # for a given pixel. The default order is compatible with the
     # order returned by hp.get_all_neighbours().
     which = np.arange(8)
@@ -114,26 +114,3 @@ def get_margin(order, pix, d_order):
             margins.append(get_edge(d_order, pixel, edge))
     margins = np.concatenate(margins)
     return margins
-
-
-def pixel_is_polar(order, pix):
-    """Checks if a healpixel is a polar pixel.
-
-    Args:
-        order (int): the healpix order of the pixel to be checked.
-        pix (int): the id of a healpixel to be checked. must be in the nested id scheme.
-    Returns:
-        tuple of a boolean and a string, the boolean indicating whether the pixel
-        polar and the string denoting which pole it is ('North' or 'South')).
-        string is empty in the case that the pixel isn't polar.
-    """
-    nside = hp.order2nside(order)
-    npix = hp.nside2npix(nside)
-    ring_pix = hp.nest2ring(nside, pix)
-
-    # in the ring numbering scheme, the first and last 4 pixels are the poles.
-    if ring_pix <= 3:
-        return (True, "North")
-    if ring_pix >= npix - 4:
-        return (True, "South")
-    return (False, "")

--- a/tests/hipscat/pixel_math/test_pixel_margins.py
+++ b/tests/hipscat/pixel_math/test_pixel_margins.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-import hipscat.pixel_math as pm
+import hipscat.pixel_math.pixel_margins as pm
 
 
 def test_get_margin():
@@ -137,36 +137,3 @@ def test_edge_greater_than_7():
         pm.get_edge(2, 5, 8)
 
     assert str(value_error.value) == "edge can only be values between 0 and 7 (see docstring)"
-
-
-def test_pixel_is_polar_north():
-    """Check to make sure pixel_is_polar works for a pixel at the north pole."""
-    order = 2
-    pix = 31
-
-    polar, pole = pm.pixel_is_polar(order, pix)
-
-    assert polar
-    assert pole == "North"
-
-
-def test_pixel_is_polar_south():
-    """Check to make sure pixel_is_polar works for a pixel at the south pole."""
-    order = 2
-    pix = 160
-
-    polar, pole = pm.pixel_is_polar(order, pix)
-
-    assert polar
-    assert pole == "South"
-
-
-def test_pixel_is_polar_non_pole():
-    """Check to make sure pixel_is_polar works for non-polar pixels."""
-    order = 2
-    pix = 105
-
-    polar, pole = pm.pixel_is_polar(order, pix)
-
-    assert not polar
-    assert pole == ""


### PR DESCRIPTION
## Change Description

Methods were unused by margin generation filtering code, either in import or LSDB packages.