### PR TITLE
Override catalog's `__len__` method

### DIFF
--- a/src/hipscat/catalog/dataset/base_catalog_info.py
+++ b/src/hipscat/catalog/dataset/base_catalog_info.py
@@ -20,7 +20,7 @@ class BaseCatalogInfo:
 
     total_rows: int | None = None
     """The number of rows in the catalog. This value is undetermined when the catalog is 
-    modified by queries and spatial searches, in which case it is set to None."""
+    modified, and therefore it is set to None."""
 
     DEFAULT_TYPE = None
     """The default catalog type for this catalog info type. To be overridden by subclasses.

--- a/src/hipscat/catalog/dataset/base_catalog_info.py
+++ b/src/hipscat/catalog/dataset/base_catalog_info.py
@@ -17,7 +17,10 @@ class BaseCatalogInfo:
 
     catalog_name: str = ""
     catalog_type: CatalogType | None = None
+
     total_rows: int | None = None
+    """The number of rows in the catalog. This value is undetermined when the catalog is 
+    modified by queries and spatial searches, in which case it is set to None."""
 
     DEFAULT_TYPE = None
     """The default catalog type for this catalog info type. To be overridden by subclasses.

--- a/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
@@ -152,14 +152,11 @@ class HealpixDataset(Dataset):
 
         Returns:
             The number of rows in the catalog, as specified in its metadata.
-            This value is undetermined if the catalog was modified by means
-            of queries and spatial filters, in which case it raises an error.
+            This value is undetermined when the catalog is modified, and
+            therefore an error is raised.
         """
         if self.catalog_info.total_rows is None:
-            raise ValueError(
-                "The number of rows is undetermined because the catalog "
-                "was modified by filtering operations."
-            )
+            raise ValueError("The number of rows is undetermined because the catalog was modified.")
         return self.catalog_info.total_rows
 
     def get_max_coverage_order(self) -> int:

--- a/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hipscat/catalog/healpix_dataset/healpix_dataset.py
@@ -147,6 +147,21 @@ class HealpixDataset(Dataset):
                 f"_metadata or partition info file is required in catalog directory {catalog_base_dir}"
             )
 
+    def __len__(self):
+        """The number of rows in the catalog.
+
+        Returns:
+            The number of rows in the catalog, as specified in its metadata.
+            This value is undetermined if the catalog was modified by means
+            of queries and spatial filters, in which case it raises an error.
+        """
+        if self.catalog_info.total_rows is None:
+            raise ValueError(
+                "The number of rows is undetermined because the catalog "
+                "was modified by filtering operations."
+            )
+        return self.catalog_info.total_rows
+
     def get_max_coverage_order(self) -> int:
         """Gets the maximum HEALPix order for which the coverage of the catalog is known from the pixel
         tree and moc if it exists"""

--- a/tests/hipscat/catalog/test_catalog.py
+++ b/tests/hipscat/catalog/test_catalog.py
@@ -23,6 +23,7 @@ def test_catalog_load(catalog_info, catalog_pixels):
     catalog = Catalog(catalog_info, catalog_pixels)
     assert catalog.get_healpix_pixels() == catalog_pixels
     assert catalog.catalog_name == catalog_info.catalog_name
+    assert catalog_info.total_rows == len(catalog)
 
     for hp_pixel in catalog_pixels:
         assert hp_pixel in catalog.pixel_tree
@@ -574,3 +575,17 @@ def test_generate_negative_tree_pixels_multi_order(small_sky_order1_catalog):
     negative_tree = small_sky_order1_catalog.generate_negative_tree_pixels()
 
     assert negative_tree == expected_pixels
+
+
+def test_catalog_len_is_undetermined(small_sky_order1_catalog):
+    """Tests that catalogs modified by queries and spatial filters have an undetermined
+    number of rows, case in which an error is thrown"""
+    with pytest.raises(ValueError, match="undetermined"):
+        len(small_sky_order1_catalog.filter_by_cone(0, -80, 1))
+    with pytest.raises(ValueError, match="undetermined"):
+        vertices = [(300, -50), (300, -55), (272, -55), (272, -50)]
+        len(small_sky_order1_catalog.filter_by_polygon(vertices))
+    with pytest.raises(ValueError, match="undetermined"):
+        len(small_sky_order1_catalog.filter_by_box(ra=(280, 300)))
+    with pytest.raises(ValueError, match="undetermined"):
+        len(small_sky_order1_catalog.filter_from_pixel_list([HealpixPixel(0, 11)]))


### PR DESCRIPTION
Override the built-in `__len__` method to provide the number of rows for unmodified catalogs. Closes #333. 

- [X] My PR includes a link to the issue that I am addressing

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation