### PR TITLE
Add sparse histogram implementation

### DIFF
--- a/src/hipscat/pixel_math/sparse_histogram.py
+++ b/src/hipscat/pixel_math/sparse_histogram.py
@@ -1,0 +1,102 @@
+"""Sparse 1-D histogram of healpix pixel counts."""
+
+import numpy as np
+from scipy.sparse import csc_array, load_npz, save_npz, sparray
+
+import hipscat.pixel_math.healpix_shim as hp
+
+
+class SparseHistogram:
+    """Wrapper around scipy's sparse array."""
+
+    def __init__(self, sparse_array):
+        if not isinstance(sparse_array, sparray):
+            raise ValueError("The sparse array must be a scipy sparse array.")
+        if sparse_array.format != "csc":
+            raise ValueError("The sparse array must be a Compressed Sparse Column array.")
+        self.sparse_array = sparse_array
+
+    def add(self, other):
+        """Add in another sparse histogram, updating this wrapper's array.
+
+        Args:
+            other (SparseHistogram): the wrapper containing the addend
+        """
+        if not isinstance(other, SparseHistogram):
+            raise ValueError("Both addends should be SparseHistogram.")
+        if self.sparse_array.shape != other.sparse_array.shape:
+            raise ValueError(
+                "The histogram partials have incompatible sizes due to different healpix orders. "
+                + "To start the pipeline from scratch with the current order set `resume` to False."
+            )
+        self.sparse_array += other.sparse_array
+
+    def to_array(self):
+        """Convert the sparse array to a dense numpy array.
+
+        Returns:
+            dense 1-d numpy array.
+        """
+        return self.sparse_array.toarray()[0]
+
+    def to_file(self, file_name):
+        """Persist the sparse array to disk.
+
+        NB: this saves as a sparse array, and so will likely have lower space requirements
+        than saving the corresponding dense 1-d numpy array.
+        """
+        save_npz(file_name, self.sparse_array)
+
+    def to_dense_file(self, file_name):
+        """Persist the DENSE array to disk as a numpy array."""
+        with open(file_name, "wb+") as file_handle:
+            file_handle.write(self.to_array().data)
+
+    @classmethod
+    def make_empty(cls, healpix_order=10):
+        """Create an empty sparse array for a given healpix order.
+
+        Args:
+            healpix_order (int): healpix order
+
+        Returns:
+            new sparse histogram
+        """
+        histo = csc_array((1, hp.order2npix(healpix_order)), dtype=np.int64)
+        return cls(histo)
+
+    @classmethod
+    def make_from_counts(cls, indexes, counts_at_indexes, healpix_order=10):
+        """Create an sparse array for a given healpix order, prefilled with counts at
+        the provided indexes.
+
+        e.g. for a dense 1-d numpy histogram of order 0, you might see::
+
+            [0, 4, 0, 0, 0, 0, 0, 0, 9, 0, 0]
+
+        There are only elements at [1, 8], and they have respective values [4, 9]. You
+        would create the sparse histogram like::
+
+            make_from_counts([1, 8], [4, 9], 0)
+
+        Args:
+            indexes (int[]): index locations of non-zero values
+            counts_at_indexes (int[]): values at the ``indexes``
+            healpix_order (int): healpix order
+
+        Returns:
+            new sparse histogram
+        """
+        row = np.array(np.zeros(len(indexes), dtype=np.int64))
+        histo = csc_array((counts_at_indexes, (row, indexes)), shape=(1, hp.order2npix(healpix_order)))
+        return cls(histo)
+
+    @classmethod
+    def from_file(cls, file_name):
+        """Read sparse histogram from a file.
+
+        Returns:
+            new sparse histogram
+        """
+        histo = load_npz(file_name)
+        return cls(histo)

--- a/tests/hipscat/pixel_math/test_sparse_histogram.py
+++ b/tests/hipscat/pixel_math/test_sparse_histogram.py
@@ -1,0 +1,64 @@
+"""Test sparse histogram behavior."""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+from scipy.sparse import csr_array
+
+from hipscat.pixel_math.sparse_histogram import SparseHistogram
+
+
+def test_read_write_round_trip(tmp_path):
+    """Test that we can read what we write into a histogram file."""
+    file_name = tmp_path / "round_trip.npz"
+    histogram = SparseHistogram.make_from_counts([11], [131], 0)
+    histogram.to_file(file_name)
+
+    read_histogram = SparseHistogram.from_file(file_name)
+
+    npt.assert_array_equal(read_histogram.to_array(), histogram.to_array())
+
+
+def test_add_same_order():
+    """Test that we can add two histograms created from the same order, and get
+    the expected results."""
+    partial_histogram_left = SparseHistogram.make_from_counts([11], [131], 0)
+
+    partial_histogram_right = SparseHistogram.make_from_counts([10, 11], [4, 15], 0)
+
+    partial_histogram_left.add(partial_histogram_right)
+
+    expected = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 146]
+    npt.assert_array_equal(partial_histogram_left.to_array(), expected)
+
+
+def test_add_different_order():
+    """Test that we can NOT add histograms of different healpix orders."""
+    partial_histogram_left = SparseHistogram.make_from_counts([11], [131], 0)
+
+    partial_histogram_right = SparseHistogram.make_from_counts([10, 11], [4, 15], 1)
+
+    with pytest.raises(ValueError, match="partials have incompatible sizes"):
+        partial_histogram_left.add(partial_histogram_right)
+
+
+def test_add_different_type():
+    """Test that we can NOT add histograms of different healpix orders."""
+    partial_histogram_left = SparseHistogram.make_from_counts([11], [131], 0)
+
+    with pytest.raises(ValueError, match="addends should be SparseHistogram"):
+        partial_histogram_left.add(5)
+
+    with pytest.raises(ValueError, match="addends should be SparseHistogram"):
+        partial_histogram_left.add([1, 2, 3, 4, 5])
+
+
+def test_init_bad_inputs():
+    """Test that the SparseHistogram type requires a compressed sparse column
+    as its sole `sparse_array` argument."""
+    with pytest.raises(ValueError, match="must be a scipy sparse array"):
+        SparseHistogram(5)
+
+    with pytest.raises(ValueError, match="must be a Compressed Sparse Column"):
+        row_sparse_array = csr_array((1, 12), dtype=np.int64)
+        SparseHistogram(row_sparse_array)


### PR DESCRIPTION
Move the [`SparseHistogram`](https://github.com/astronomy-commons/hipscat-import/blob/main/src/hipscat_import/catalog/sparse_histogram.py) implementation that currently resides in the importer to hipscat. LSDB will use it to compute the point map distributions more efficiently.

- [ ] My PR includes a link to the issue that I am addressing


## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation